### PR TITLE
Fix PowerSync WASM loading failure on web (#40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "postinstall": "npx powersync-web copy-assets --output public"
+    "postinstall": "npx powersync-web copy-assets --output public && cp node_modules/@journeyapps/wa-sqlite/dist/wa-sqlite-async.wasm public/"
   },
   "dependencies": {
     "@journeyapps/wa-sqlite": "^1.5.0",


### PR DESCRIPTION
## Summary

Fixes the web app crashing on startup with WASM loading failures after the recent merge to main.

## Problem

Metro bundles `@powersync/web` source → `wa-sqlite-async.mjs` resolves its WASM path via `import.meta.url` → Babel transforms this to `globalThis.location.href` → request goes to `http://localhost:8081/wa-sqlite-async.wasm` → **no such file exists** → Metro returns HTML → WASM loader sees `<!DO` instead of magic bytes → crash.

The existing `postinstall` script copies pre-built UMD bundles with hashed WASM to `public/@powersync/`, but does NOT copy the raw `wa-sqlite-async.wasm` to `public/` root where the Metro-bundled code resolves it.

## Fix

Enhanced the `postinstall` script to also copy the raw WASM binary:

```diff
- "postinstall": "npx powersync-web copy-assets --output public"
+ "postinstall": "npx powersync-web copy-assets --output public && cp node_modules/@journeyapps/wa-sqlite/dist/wa-sqlite-async.wasm public/"
```

## Verification

- `curl` confirms `200 application/wasm` with correct file size (2,278,923 bytes)
- `.gitignore` already has `public/*.wasm` — generated file is not tracked

Closes #40