### PR TITLE
Add shooter selection picker to scoring screen

### DIFF
--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -22,6 +22,7 @@ import { Colors, Spacing, FontSize, BorderRadius, PRESENTATION_LABELS } from '@/
 import LoadingPlaceholder from '@/components/LoadingPlaceholder';
 import PositionPicker, { type PositionStatus } from '@/components/PositionPicker';
 import StandSelector from '@/components/StandSelector';
+import ShooterPicker, { type ShooterStatus, type ShooterProgress } from '@/components/ShooterPicker';
 import {
   ShotResult,
   RoundStatus,
@@ -45,7 +46,8 @@ function birdsPerTarget(config: TargetConfig): number {
   return config === TargetConfig.SINGLE ? 1 : 2;
 }
 
-type ClubPhase = 'position-picker' | 'stand-selector' | 'scoring';
+type ClubPhase = 'position-picker' | 'stand-selector' | 'shooter-picker' | 'scoring';
+type ScoringPhase = 'shooter-picker' | 'scoring';
 
 export default function ScoringScreen() {
   const { id: roundId } = useLocalSearchParams<{ id: string }>();
@@ -73,6 +75,11 @@ export default function ScoringScreen() {
   const [createdStandMap, setCreatedStandMap] = useState<Map<string, string>>(new Map());
   /** Set of club_stand_ids that have been fully completed */
   const [completedClubStandIds, setCompletedClubStandIds] = useState<Set<string>>(new Set());
+
+  // Shooter picker state
+  const [scoringPhase, setScoringPhase] = useState<ScoringPhase>('shooter-picker');
+  const [shooterStatuses, setShooterStatuses] = useState<Record<string, ShooterStatus>>({});
+  const [shooterProgress, setShooterProgress] = useState<Record<string, ShooterProgress>>({});
 
   // Scoring state (shared)
   const [shooterIdx, setShooterIdx] = useState(0);
@@ -161,12 +168,68 @@ export default function ScoringScreen() {
     })();
   }, [currentStand?.id, currentShooter?.id]);
 
+  // Compute shooter statuses when stand changes or when returning to shooter picker
+  const refreshShooterStatuses = useCallback(
+    async (stand: Stand) => {
+      const statuses: Record<string, ShooterStatus> = {};
+      const progress: Record<string, ShooterProgress> = {};
+      const totalShots = (stand.num_targets ?? 0) * birdsPerTarget(stand.target_config as TargetConfig);
+
+      for (const shooter of shooters) {
+        const results = await getResultsForStandAndShooter(db, stand.id, shooter.id);
+        const recorded = results.length;
+        progress[shooter.id] = { recorded, total: totalShots };
+        if (recorded === 0) {
+          statuses[shooter.id] = 'not-started';
+        } else if (recorded >= totalShots) {
+          statuses[shooter.id] = 'completed';
+        } else {
+          statuses[shooter.id] = 'in-progress';
+        }
+      }
+
+      setShooterStatuses(statuses);
+      setShooterProgress(progress);
+    },
+    [db, shooters],
+  );
+
+  // Refresh statuses when the current stand changes
+  useEffect(() => {
+    if (!currentStand || shooters.length === 0) return;
+    refreshShooterStatuses(currentStand);
+  }, [currentStand?.id, shooters.length]);
+
+  function handleSelectShooter(shooter: ShooterEntry) {
+    const idx = shooters.findIndex((s) => s.id === shooter.id);
+    if (idx >= 0) {
+      setShooterIdx(idx);
+      setTargetNum(1);
+      setBirdNum(1);
+      setKillCount(0);
+      setTotalRecorded(0);
+      setScoringPhase('scoring');
+      if (isClubRound) setClubPhase('scoring');
+    }
+  }
+
+  async function returnToShooterPicker() {
+    if (currentStand) {
+      await refreshShooterStatuses(currentStand);
+    }
+    setScoringPhase('shooter-picker');
+    if (isClubRound) setClubPhase('shooter-picker');
+  }
+
   const standComplete = currentStand
     ? targetNum > (currentStand.num_targets ?? 0)
     : false;
 
   const isLastStand = standIdx === stands.length - 1;
   const isLastShooter = shooterIdx === shooters.length - 1;
+  const allShootersCompleted = shooters.length > 0 && shooters.every(
+    (s) => (shooterStatuses[s.id] ?? 'not-started') === 'completed',
+  );
 
   // --- Scoring handler (shared) ---
   const handleScore = useCallback(
@@ -202,22 +265,14 @@ export default function ScoringScreen() {
   );
 
   // --- Custom mode navigation ---
-  function handleNextShooter() {
-    if (!isLastShooter) {
-      setShooterIdx((i) => i + 1);
-      setTargetNum(1);
-      setBirdNum(1);
-      setKillCount(0);
-      setTotalRecorded(0);
-    } else {
-      handleNextStand();
-    }
+  function handleReturnToShooterPicker() {
+    returnToShooterPicker();
   }
 
   function handleNextStand() {
     if (!isLastStand) {
       setStandIdx((i) => i + 1);
-      setShooterIdx(0);
+      setScoringPhase('shooter-picker');
       setTargetNum(1);
       setBirdNum(1);
       setKillCount(0);
@@ -273,12 +328,8 @@ export default function ScoringScreen() {
     };
 
     setCurrentClubStand(stand);
-    setShooterIdx(0);
-    setTargetNum(1);
-    setBirdNum(1);
-    setKillCount(0);
-    setTotalRecorded(0);
-    setClubPhase('scoring');
+    setScoringPhase('shooter-picker');
+    setClubPhase('shooter-picker');
   }
 
   function handleClubStandComplete() {
@@ -296,17 +347,8 @@ export default function ScoringScreen() {
     setClubPhase('position-picker');
   }
 
-  function handleClubNextShooter() {
-    if (!isLastShooter) {
-      setShooterIdx((i) => i + 1);
-      setTargetNum(1);
-      setBirdNum(1);
-      setKillCount(0);
-      setTotalRecorded(0);
-    } else {
-      // All shooters done at this stand
-      handleClubStandComplete();
-    }
+  function handleClubReturnToShooterPicker() {
+    returnToShooterPicker();
   }
 
   // --- Shared ---
@@ -361,6 +403,42 @@ export default function ScoringScreen() {
         completedStandIds={completedClubStandIds}
         onSelectStand={handleSelectClubStand}
         onBack={() => setClubPhase('position-picker')}
+      />
+    );
+  }
+
+  // --- Club mode: shooter picker ---
+  if (isClubRound && clubPhase === 'shooter-picker' && currentClubStand) {
+    const standLabel = `Stand ${currentClubStand.stand_number}`;
+    return (
+      <ShooterPicker
+        standLabel={standLabel}
+        shooters={shooters}
+        shooterStatuses={shooterStatuses}
+        shooterProgress={shooterProgress}
+        onSelectShooter={handleSelectShooter}
+        onBack={() => {
+          setCurrentClubStand(null);
+          setClubPhase('stand-selector');
+        }}
+        onAllComplete={handleClubStandComplete}
+        allCompleteLabel="Choose Next Position"
+      />
+    );
+  }
+
+  // --- Custom mode: shooter picker ---
+  if (!isClubRound && scoringPhase === 'shooter-picker' && currentStand) {
+    const standLabel = `Stand ${currentStand.stand_number}/${stands.length}`;
+    return (
+      <ShooterPicker
+        standLabel={standLabel}
+        shooters={shooters}
+        shooterStatuses={shooterStatuses}
+        shooterProgress={shooterProgress}
+        onSelectShooter={handleSelectShooter}
+        onAllComplete={isLastStand ? handleFinish : handleNextStand}
+        allCompleteLabel={isLastStand ? 'Finish Round' : 'Next Stand'}
       />
     );
   }
@@ -424,24 +502,16 @@ export default function ScoringScreen() {
             {isClubRound ? (
               <TouchableOpacity
                 style={styles.nextBtn}
-                onPress={isLastShooter ? handleClubStandComplete : handleClubNextShooter}
+                onPress={handleClubReturnToShooterPicker}
               >
-                <Text style={styles.nextBtnText}>
-                  {isLastShooter ? 'Choose Next Position' : 'Next Shooter'}
-                </Text>
+                <Text style={styles.nextBtnText}>Choose Next Shooter</Text>
               </TouchableOpacity>
             ) : (
               <TouchableOpacity
                 style={styles.nextBtn}
-                onPress={isLastShooter && isLastStand ? handleFinish : handleNextShooter}
+                onPress={handleReturnToShooterPicker}
               >
-                <Text style={styles.nextBtnText}>
-                  {isLastShooter && isLastStand
-                    ? 'Finish Round'
-                    : isLastShooter
-                      ? 'Next Stand'
-                      : 'Next Shooter'}
-                </Text>
+                <Text style={styles.nextBtnText}>Choose Next Shooter</Text>
               </TouchableOpacity>
             )}
           </View>

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -7,7 +7,8 @@ import {
   Alert,
   Platform,
 } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import { useNavigation } from '@react-navigation/native';
 import { usePowerSync } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { Ionicons } from '@expo/vector-icons';
@@ -220,6 +221,65 @@ export default function ScoringScreen() {
     setScoringPhase('shooter-picker');
     if (isClubRound) setClubPhase('shooter-picker');
   }
+
+  // Navigate back within the scoring state machine
+  function handleHeaderBack() {
+    if (isClubRound) {
+      switch (clubPhase) {
+        case 'scoring':
+          returnToShooterPicker();
+          break;
+        case 'shooter-picker':
+          setCurrentClubStand(null);
+          setClubPhase('stand-selector');
+          break;
+        case 'stand-selector':
+          setSelectedPosition(null);
+          setClubPhase('position-picker');
+          break;
+        default:
+          router.back();
+      }
+    } else {
+      if (scoringPhase === 'scoring') {
+        returnToShooterPicker();
+      } else {
+        router.back();
+      }
+    }
+  }
+
+  // Compute contextual header title
+  const headerTitle = useMemo(() => {
+    if (isClubRound) {
+      switch (clubPhase) {
+        case 'position-picker': return 'Scoring';
+        case 'stand-selector': return 'Choose Stand';
+        case 'shooter-picker': return 'Choose Shooter';
+        case 'scoring': return 'Scoring';
+      }
+    }
+    return scoringPhase === 'shooter-picker' ? 'Choose Shooter' : 'Scoring';
+  }, [isClubRound, clubPhase, scoringPhase]);
+
+  // Whether the header back button should exit the round or navigate within the state machine
+  const showInternalBack = isClubRound
+    ? clubPhase !== 'position-picker'
+    : scoringPhase === 'scoring';
+
+  const navigation = useNavigation();
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: headerTitle,
+      headerLeft: showInternalBack
+        ? () => (
+            <TouchableOpacity onPress={handleHeaderBack} style={{ paddingRight: Spacing.sm }}>
+              <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+            </TouchableOpacity>
+          )
+        : undefined,
+    });
+  }, [navigation, headerTitle, showInternalBack, handleHeaderBack]);
 
   const standComplete = currentStand
     ? targetNum > (currentStand.num_targets ?? 0)

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -473,12 +473,10 @@ export default function ScoringScreen() {
             {PRESENTATION_LABELS[currentStand.presentation as PresentationType]}
           </Text>
         </View>
-        <View style={styles.shooterBox}>
+        <TouchableOpacity style={styles.shooterBox} onPress={returnToShooterPicker}>
           <Text style={styles.shooterLabel}>{currentShooter.shooter_name}</Text>
-          <Text style={styles.shooterDetail}>
-            Shooter {shooterIdx + 1}/{shooters.length}
-          </Text>
-        </View>
+          <Text style={styles.changeShooterHint}>✎ Change</Text>
+        </TouchableOpacity>
       </View>
 
       {/* Target info */}
@@ -596,6 +594,12 @@ const styles = StyleSheet.create({
   shooterDetail: {
     fontSize: FontSize.xs,
     color: Colors.textSecondary,
+  },
+  changeShooterHint: {
+    fontSize: FontSize.xs,
+    color: Colors.primary,
+    fontWeight: '600',
+    marginTop: 2,
   },
   targetInfo: {
     paddingVertical: Spacing.lg,

--- a/components/ShooterPicker.tsx
+++ b/components/ShooterPicker.tsx
@@ -1,0 +1,198 @@
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import { Colors, Spacing, FontSize, BorderRadius, MIN_TAP_TARGET_SIZE } from '@/lib/constants';
+import type { ShooterEntry } from '@/lib/types';
+
+export type ShooterStatus = 'not-started' | 'in-progress' | 'completed';
+
+export interface ShooterProgress {
+  recorded: number;
+  total: number;
+}
+
+interface ShooterPickerProps {
+  standLabel: string;
+  shooters: ShooterEntry[];
+  shooterStatuses: Record<string, ShooterStatus>;
+  shooterProgress: Record<string, ShooterProgress>;
+  onSelectShooter: (shooter: ShooterEntry) => void;
+  onBack?: () => void;
+  /** Action when all shooters at this stand are completed */
+  onAllComplete?: () => void;
+  allCompleteLabel?: string;
+}
+
+const STATUS_COLORS: Record<ShooterStatus, string> = {
+  'not-started': Colors.bgTertiary,
+  'in-progress': '#FEF3C7',
+  completed: '#DCFCE7',
+};
+
+const STATUS_BORDER: Record<ShooterStatus, string> = {
+  'not-started': Colors.border,
+  'in-progress': Colors.noBird,
+  completed: Colors.hit,
+};
+
+const STATUS_LABELS: Record<ShooterStatus, string> = {
+  'not-started': 'Not Started',
+  'in-progress': 'In Progress',
+  completed: 'Completed',
+};
+
+export default function ShooterPicker({
+  standLabel,
+  shooters,
+  shooterStatuses,
+  shooterProgress,
+  onSelectShooter,
+  onBack,
+  onAllComplete,
+  allCompleteLabel,
+}: ShooterPickerProps) {
+  const allCompleted = shooters.length > 0 && shooters.every(
+    (s) => (shooterStatuses[s.id] ?? 'not-started') === 'completed',
+  );
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.header}>
+        {onBack && (
+          <TouchableOpacity onPress={onBack}>
+            <Text style={styles.backText}>← Back</Text>
+          </TouchableOpacity>
+        )}
+        <Text style={styles.title}>{standLabel}</Text>
+      </View>
+
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
+        <Text style={styles.subtitle}>Choose a Shooter</Text>
+
+        {shooters.map((shooter) => {
+          const status = shooterStatuses[shooter.id] ?? 'not-started';
+          const progress = shooterProgress[shooter.id];
+          return (
+            <TouchableOpacity
+              key={shooter.id}
+              style={[
+                styles.shooterCard,
+                { backgroundColor: STATUS_COLORS[status], borderColor: STATUS_BORDER[status] },
+              ]}
+              onPress={() => onSelectShooter(shooter)}
+            >
+              <View style={styles.shooterHeader}>
+                <Text style={styles.shooterName}>{shooter.shooter_name}</Text>
+                <Text style={[styles.statusBadge, { color: STATUS_BORDER[status] }]}>
+                  {STATUS_LABELS[status]}
+                </Text>
+              </View>
+              <Text style={styles.shooterMeta}>
+                Position {shooter.position_in_squad}
+                {progress ? ` · ${progress.recorded}/${progress.total} targets` : ''}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      {allCompleted && onAllComplete && (
+        <View style={styles.footer}>
+          <TouchableOpacity style={styles.nextBtn} onPress={onAllComplete}>
+            <Text style={styles.nextBtnText}>
+              {allCompleteLabel ?? 'Continue'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    backgroundColor: Colors.bgSecondary,
+    gap: Spacing.md,
+  },
+  backText: {
+    fontSize: FontSize.base,
+    color: Colors.primary,
+    fontWeight: '600',
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
+  scroll: {
+    flex: 1,
+  },
+  container: {
+    padding: Spacing.lg,
+    paddingBottom: Spacing.xxl,
+  },
+  subtitle: {
+    fontSize: FontSize['2xl'],
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    marginBottom: Spacing.lg,
+  },
+  shooterCard: {
+    borderWidth: 1,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    marginBottom: Spacing.sm,
+    minHeight: MIN_TAP_TARGET_SIZE,
+  },
+  shooterHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  shooterName: {
+    fontSize: FontSize.lg,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+    flex: 1,
+  },
+  statusBadge: {
+    fontSize: FontSize.xs,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  shooterMeta: {
+    fontSize: FontSize.sm,
+    color: Colors.textSecondary,
+    marginTop: Spacing.xs,
+  },
+  footer: {
+    padding: Spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    backgroundColor: Colors.bgSecondary,
+  },
+  nextBtn: {
+    backgroundColor: Colors.primary,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+  },
+  nextBtnText: {
+    fontSize: FontSize.lg,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+});


### PR DESCRIPTION
## What

Replace the sequential shooter cycling (1→2→3→done) with an explicit shooter picker screen during scoring. Scorers now choose which shooter to score at each stand, see live progress, and can change their selection at any time.

Closes #37

## Why

The old sequential flow forced scorers to record results in a fixed shooter order. This didn't match real-world usage where scorers may need to skip shooters, re-score, or score out of order. The picker gives full control and visibility.

## Changes

### New: `components/ShooterPicker.tsx`
- Card-based picker showing all shooters for the current stand
- Status badges: not-started (gray), in-progress (yellow), completed (green)
- Progress indicator (e.g. "3/5 targets") per shooter
- "All Complete" footer button when every shooter is done
- Follows existing PositionPicker/StandSelector patterns

### Modified: `app/round/[id]/score.tsx`
- Added `shooter-picker` phase to both custom and club scoring flows
- Compute shooter statuses by querying recorded results per stand/shooter
- Tappable shooter name in scoring top bar with "✎ Change" hint to return to picker
- Custom header back button navigates through state machine phases (scoring → shooter-picker → stand-selector → position-picker → exit) instead of immediately leaving the round
- Removed `handleNextShooter()` sequential cycling