### PR TITLE
Fix profile-setup redirect on new device login

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { usePowerSync } from '@powersync/react';
 import type { User } from '@/lib/types';
 import { useDatabase } from './DatabaseProvider';
@@ -52,12 +52,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setSession(newSession);
 
       if (newSession?.user && event !== 'SIGNED_OUT') {
+        // Keep the router from acting while we resolve the user record
+        setIsLoading(true);
         await syncUserWithDatabase(newSession.user.id, newSession.user.email || null);
+        if (mounted) setIsLoading(false);
       } else if (event === 'SIGNED_OUT') {
         setUser(null);
       }
 
-      // Mark loading done after initial session event
+      // Mark loading done after initial session event (handles no-session case)
       if (event === 'INITIAL_SESSION') {
         setIsLoading(false);
       }
@@ -72,7 +75,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   /**
    * Sync Supabase auth user with local database User table.
    * If PowerSync has already synced the profile, use it.
-   * Otherwise create a blank record — PowerSync will merge remote data once sync completes.
+   * Otherwise query Supabase directly (user just authenticated, so network is available).
+   * Only create a blank record if no remote profile exists (true first-time user).
    */
   async function syncUserWithDatabase(userId: string, email: string | null) {
     if (!db) {
@@ -92,9 +96,45 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Not found locally yet — create a record.
-      // PowerSync will upload this to Supabase, and if a remote record
-      // already exists, the upsert in uploadData will merge it.
+      // Not found locally — check Supabase for an existing profile.
+      // The user just authenticated so network should be available.
+      let remoteUser: User | null = null;
+      try {
+        const { data } = await supabase
+          .from('users')
+          .select('*')
+          .eq('id', userId)
+          .single();
+        if (data) {
+          remoteUser = data as User;
+        }
+      } catch {
+        // Network or query error — fall through to blank record creation
+      }
+
+      if (remoteUser) {
+        // Profile exists on Supabase — insert it locally so the router
+        // sees the real profile state immediately.
+        await db.execute(
+          `INSERT INTO users (id, display_name, email, user_id, discoverable, favourite_club_ids, gear, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            remoteUser.id,
+            remoteUser.display_name,
+            remoteUser.email,
+            remoteUser.user_id,
+            remoteUser.discoverable,
+            remoteUser.favourite_club_ids,
+            remoteUser.gear,
+            remoteUser.created_at,
+            remoteUser.updated_at,
+          ]
+        );
+        setUser(remoteUser);
+        return;
+      }
+
+      // No remote profile — true first-time user. Create a blank record.
       const now = new Date().toISOString();
       const newUser: User = {
         id: userId,
@@ -187,6 +227,38 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       console.error('Error refreshing user:', error instanceof Error ? error.message : error);
     }
   };
+
+  // Watch for PowerSync changes to the user record.
+  // Handles the case where PowerSync syncs the real profile after initial load.
+  const watchedUserId = useRef<string | null>(null);
+  useEffect(() => {
+    if (!db || !user?.id) return;
+    // Avoid re-subscribing for the same user
+    if (watchedUserId.current === user.id) return;
+    watchedUserId.current = user.id;
+
+    const abort = new AbortController();
+    const userId = user.id;
+
+    db.watch(
+      'SELECT * FROM users WHERE id = ?',
+      [userId],
+      {
+        onResult(results) {
+          const updated = results.rows?._array?.[0];
+          if (updated) {
+            setUser(updated as User);
+          }
+        },
+      },
+      { signal: abort.signal }
+    );
+
+    return () => {
+      watchedUserId.current = null;
+      abort.abort();
+    };
+  }, [db, user?.id]);
 
   const value: AuthContextValue = {
     user,


### PR DESCRIPTION
Closes #42

## Problem

Logging in on a new device forces the user through the "Complete Your Profile" screen every time, even though their profile data already exists on Supabase.

**Root cause:** `syncUserWithDatabase()` finds an empty local SQLite DB (fresh device), creates a blank user record with `user_id: null`, and the router immediately redirects to profile-setup. PowerSync eventually syncs the real profile — but too late. The blank record also risks overwriting the real Supabase profile via the CRUD upload queue.

## Solution

Three changes in `AuthProvider.tsx`:

1. **Query Supabase before creating a blank record** — When no local user record exists, query Supabase directly (`supabase.from('users').select('*').eq('id', userId).single()`). If a profile exists remotely, insert it into the local DB immediately so the router sees `profileComplete: true`. Only create a blank record for true first-time users. Falls back to current behavior if the query fails (offline edge case).

2. **Reactive PowerSync watch** — A `db.watch()` subscription on the user record ensures that if PowerSync syncs updated profile data after initial load, the auth state updates reactively (safety net).

3. **Hold loading state during sync** — `setIsLoading(true)` before `syncUserWithDatabase()`, `setIsLoading(false)` after. This prevents a flash of the profile-setup screen while the async Supabase query resolves.

## Testing

- **First-time signup:** Profile-setup screen appears as expected
- **New device login (profile exists):** Goes straight to home screen
- **Same device re-login:** Goes straight to home screen (no regression)
- **Offline fallback:** Falls back to blank record creation (same as before)