### PR TITLE
Fix club dropdown pushing fields down on New Round screen

### DIFF
--- a/app/(tabs)/new-round.tsx
+++ b/app/(tabs)/new-round.tsx
@@ -7,6 +7,7 @@ import {
   View,
   ScrollView,
   Alert,
+  Platform,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
@@ -118,7 +119,7 @@ export default function NewRoundScreen() {
   }
 
   return (
-    <ScrollView style={styles.scroll} contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled" onScrollBeginDrag={() => setShowClubDropdown(false)}>
       {/* Club Selection */}
       <Text style={styles.label}>Club (optional)</Text>
       <View style={styles.clubSearchContainer}>
@@ -311,6 +312,12 @@ const styles = StyleSheet.create({
     marginLeft: Spacing.sm,
   },
   dropdown: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    ...Platform.select({ android: { elevation: 10 } }),
     borderWidth: 1,
     borderColor: Colors.border,
     borderRadius: BorderRadius.md,


### PR DESCRIPTION
## Summary

Fixes #43 — When selecting a club on the New Round screen, the dropdown pushed all other fields lower on the page, creating a jarring layout shift.

## Changes

Converted the club search dropdown from inline document flow to an absolutely-positioned overlay:

- **Absolute positioning** — `position: 'absolute'` with `top: '100%'`, `left: 0`, `right: 0` so the dropdown floats over form fields instead of pushing them down
- **z-index layering** — `zIndex: 20` on the dropdown (parent container already had `zIndex: 10` and `position: 'relative'`)
- **Android support** — `elevation: 10` via `Platform.select` since Android ignores `zIndex` without it
- **Dismiss on scroll** — `onScrollBeginDrag` on the `ScrollView` closes the dropdown when the user starts scrolling

## Testing

- [ ] Search for a club → dropdown overlays Date/Total Targets fields (no layout shift)
- [ ] Select a club → displays correctly, dropdown closes
- [ ] Clear selection → search input reappears, layout intact
- [ ] Scroll while dropdown open → dropdown dismisses
- [ ] Verify on Android (elevation ensures proper layering)