### PR TITLE
Show squad members with handles on scoring screen

### DIFF
--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -14,7 +14,7 @@ import * as Crypto from 'expo-crypto';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@/providers/AuthProvider';
 import { getRound } from '@/db/queries/rounds';
-import { getSquadByRound, listShooterEntries } from '@/db/queries/squads';
+import { getSquadByRound, listShooterEntriesWithUsers } from '@/db/queries/squads';
 import { listStands, createStand } from '@/db/queries/stands';
 import { recordTargetResult, getResultsForStandAndShooter, getRoundConflicts, type ConflictedShotGroup } from '@/db/queries/scoring';
 import { updateRoundStatus } from '@/db/queries/rounds';
@@ -29,7 +29,7 @@ import {
   RoundStatus,
   TargetConfig,
   type Stand,
-  type ShooterEntry,
+  type EnrichedShooterEntry,
   type PresentationType,
   type Round,
   type ClubStand,
@@ -58,7 +58,7 @@ export default function ScoringScreen() {
 
   // Shared state
   const [round, setRound] = useState<Round | null>(null);
-  const [shooters, setShooters] = useState<ShooterEntry[]>([]);
+  const [shooters, setShooters] = useState<EnrichedShooterEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [conflicts, setConflicts] = useState<ConflictedShotGroup[]>([]);
   const deviceId = useMemo(() => `web-${user?.id?.slice(0, 8) ?? 'anon'}`, [user]);
@@ -103,7 +103,7 @@ export default function ScoringScreen() {
 
       const squad = await getSquadByRound(db, roundId);
       if (squad) {
-        const entries = await listShooterEntries(db, squad.id);
+        const entries = await listShooterEntriesWithUsers(db, squad.id);
         setShooters(entries);
       }
 

--- a/components/ShooterPicker.tsx
+++ b/components/ShooterPicker.tsx
@@ -6,7 +6,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { Colors, Spacing, FontSize, BorderRadius, MIN_TAP_TARGET_SIZE } from '@/lib/constants';
-import type { ShooterEntry } from '@/lib/types';
+import type { ShooterEntry, EnrichedShooterEntry } from '@/lib/types';
 
 export type ShooterStatus = 'not-started' | 'in-progress' | 'completed';
 
@@ -17,10 +17,10 @@ export interface ShooterProgress {
 
 interface ShooterPickerProps {
   standLabel: string;
-  shooters: ShooterEntry[];
+  shooters: (ShooterEntry | EnrichedShooterEntry)[];
   shooterStatuses: Record<string, ShooterStatus>;
   shooterProgress: Record<string, ShooterProgress>;
-  onSelectShooter: (shooter: ShooterEntry) => void;
+  onSelectShooter: (shooter: ShooterEntry | EnrichedShooterEntry) => void;
   onBack?: () => void;
   /** Action when all shooters at this stand are completed */
   onAllComplete?: () => void;
@@ -86,7 +86,12 @@ export default function ShooterPicker({
               onPress={() => onSelectShooter(shooter)}
             >
               <View style={styles.shooterHeader}>
-                <Text style={styles.shooterName}>{shooter.shooter_name}</Text>
+                <View style={styles.shooterNameGroup}>
+                  <Text style={styles.shooterName}>{shooter.shooter_name}</Text>
+                  {'user_handle' in shooter && shooter.user_handle ? (
+                    <Text style={styles.shooterHandle}>@{shooter.user_handle}</Text>
+                  ) : null}
+                </View>
                 <Text style={[styles.statusBadge, { color: STATUS_BORDER[status] }]}>
                   {STATUS_LABELS[status]}
                 </Text>
@@ -162,11 +167,18 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
+  shooterNameGroup: {
+    flex: 1,
+  },
   shooterName: {
     fontSize: FontSize.lg,
     fontWeight: '600',
     color: Colors.textPrimary,
-    flex: 1,
+  },
+  shooterHandle: {
+    fontSize: FontSize.xs,
+    color: Colors.textSecondary,
+    marginTop: 1,
   },
   statusBadge: {
     fontSize: FontSize.xs,

--- a/db/queries/squads.ts
+++ b/db/queries/squads.ts
@@ -1,5 +1,5 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
-import type { Squad, ShooterEntry } from '@/lib/types';
+import type { Squad, ShooterEntry, EnrichedShooterEntry } from '@/lib/types';
 
 export async function createSquad(
   db: AbstractPowerSyncDatabase,
@@ -47,4 +47,18 @@ export async function removeShooterEntry(
   id: string,
 ): Promise<void> {
   await db.execute('DELETE FROM shooter_entries WHERE id = ?', [id]);
+}
+
+export async function listShooterEntriesWithUsers(
+  db: AbstractPowerSyncDatabase,
+  squadId: string,
+): Promise<EnrichedShooterEntry[]> {
+  return db.getAll<EnrichedShooterEntry>(
+    `SELECT se.*, u.user_id AS user_handle
+     FROM shooter_entries se
+     LEFT JOIN users u ON se.user_id = u.id
+     WHERE se.squad_id = ?
+     ORDER BY se.position_in_squad`,
+    [squadId],
+  );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,10 @@ export interface ShooterEntry {
   position_in_squad: number;
 }
 
+export interface EnrichedShooterEntry extends ShooterEntry {
+  user_handle: string | null;
+}
+
 export interface Stand {
   id: string;
   round_id: string;


### PR DESCRIPTION
Closes #44

## What

When a member joins a round, the ShooterPicker (shown before scoring each stand) now displays all squad members with their display name **and** handle (`@user_id`).

## Why

After accepting an invite, users had no way to see who else was in the squad. The ShooterPicker already lists all shooters before each stand — enriching it with handles gives squad visibility without adding new screens.

## Changes

- **`lib/types.ts`** — Added `EnrichedShooterEntry` interface extending `ShooterEntry` with `user_handle`
- **`db/queries/squads.ts`** — Added `listShooterEntriesWithUsers()` using LEFT JOIN to fetch user handles alongside shooter entries
- **`app/round/[id]/score.tsx`** — Switched to `listShooterEntriesWithUsers` for data loading
- **`components/ShooterPicker.tsx`** — Shooter cards now show `@handle` below the name (only for registered users; custom-name shooters show name only)