### PR TITLE
Fix duplicate stand creation race condition in club rounds

### DIFF
--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -12,6 +12,7 @@ import { useNavigation } from '@react-navigation/native';
 import { usePowerSync } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { Ionicons } from '@expo/vector-icons';
+import { deterministicUUID } from '@/lib/uuid';
 import { useAuth } from '@/providers/AuthProvider';
 import { getRound } from '@/db/queries/rounds';
 import { getSquadByRound, listShooterEntriesWithUsers } from '@/db/queries/squads';
@@ -355,7 +356,7 @@ export default function ScoringScreen() {
 
     // Create the round stand from club template if it doesn't exist yet
     if (!standId) {
-      standId = Crypto.randomUUID();
+      standId = await deterministicUUID(`${roundId}:${clubStand.id}`);
       await createStand(db, {
         id: standId,
         round_id: roundId,

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -67,6 +67,7 @@ export default function ScoringScreen() {
   // Custom mode state (sequential)
   const [stands, setStands] = useState<Stand[]>([]);
   const [standIdx, setStandIdx] = useState(0);
+  const [squadId, setSquadId] = useState<string | null>(null);
 
   // Club mode state
   const [clubPositions, setClubPositions] = useState<PositionWithStands[]>([]);
@@ -104,6 +105,7 @@ export default function ScoringScreen() {
 
       const squad = await getSquadByRound(db, roundId);
       if (squad) {
+        setSquadId(squad.id);
         const entries = await listShooterEntriesWithUsers(db, squad.id);
         setShooters(entries);
       }
@@ -142,33 +144,27 @@ export default function ScoringScreen() {
     })();
   }, [db, roundId]);
 
-  // Load existing results when stand/shooter changes to resume mid-round
+  // Reactively watch shooter entries — picks up new squad members via sync
   useEffect(() => {
-    if (!currentStand || !currentShooter) return;
-    (async () => {
-      const existing = await getResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
-      if (existing.length > 0) {
-        const lastResult = existing[existing.length - 1];
-        const kills = existing.filter((r) => r.result === ShotResult.KILL).length;
-        setKillCount(kills);
-        setTotalRecorded(existing.length);
-        const nextTarget = lastResult.target_number;
-        const nextBird = lastResult.bird_number;
-        if (nextBird < maxBirds) {
-          setTargetNum(nextTarget);
-          setBirdNum(nextBird + 1);
-        } else if (nextTarget < (currentStand.num_targets ?? 0)) {
-          setTargetNum(nextTarget + 1);
-          setBirdNum(1);
-        }
-      } else {
-        setKillCount(0);
-        setTotalRecorded(0);
-        setTargetNum(1);
-        setBirdNum(1);
-      }
-    })();
-  }, [currentStand?.id, currentShooter?.id]);
+    if (!squadId) return;
+    const abort = new AbortController();
+    db.watch(
+      `SELECT se.*, u.user_id AS user_handle
+       FROM shooter_entries se
+       LEFT JOIN users u ON se.user_id = u.id
+       WHERE se.squad_id = ?
+       ORDER BY se.position_in_squad`,
+      [squadId],
+      {
+        onResult(results) {
+          const rows = (results.rows?._array ?? []) as EnrichedShooterEntry[];
+          setShooters(rows);
+        },
+      },
+      { signal: abort.signal },
+    );
+    return () => abort.abort();
+  }, [db, squadId]);
 
   // Compute shooter statuses when stand changes or when returning to shooter picker
   const refreshShooterStatuses = useCallback(
@@ -196,11 +192,112 @@ export default function ScoringScreen() {
     [db, shooters],
   );
 
-  // Refresh statuses when the current stand changes
+  // Reactively watch stands table — picks up stands created by other users via sync
+  useEffect(() => {
+    if (!roundId || !round?.club_id) return;
+    const abort = new AbortController();
+    db.watch(
+      'SELECT id, club_stand_id FROM stands WHERE round_id = ?',
+      [roundId],
+      {
+        onResult(results) {
+          const rows = results.rows?._array ?? [];
+          const next = new Map<string, string>();
+          for (const row of rows) {
+            if (row.club_stand_id) next.set(row.club_stand_id, row.id);
+          }
+          setCreatedStandMap(next);
+        },
+      },
+      { signal: abort.signal },
+    );
+    return () => abort.abort();
+  }, [db, roundId, round?.club_id]);
+
+  // Reactively watch target_results for the current stand — updates shooter statuses in real time
+  const refreshingStandIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!currentStand || shooters.length === 0) return;
-    refreshShooterStatuses(currentStand);
-  }, [currentStand?.id, shooters.length]);
+    refreshingStandIdRef.current = currentStand.id;
+    const abort = new AbortController();
+    db.watch(
+      'SELECT shooter_entry_id, COUNT(*) as cnt FROM target_results WHERE stand_id = ? GROUP BY shooter_entry_id',
+      [currentStand.id],
+      {
+        onResult() {
+          // Any change to results for this stand → refresh statuses
+          if (refreshingStandIdRef.current === currentStand.id) {
+            refreshShooterStatuses(currentStand);
+          }
+        },
+      },
+      { signal: abort.signal },
+    );
+    return () => abort.abort();
+  }, [db, currentStand?.id, shooters.length, refreshShooterStatuses]);
+
+  // Reactively watch target_results for current stand+shooter — updates live score
+  useEffect(() => {
+    if (!currentStand || !currentShooter) return;
+    const abort = new AbortController();
+    db.watch(
+      'SELECT id FROM target_results WHERE stand_id = ? AND shooter_entry_id = ?',
+      [currentStand.id, currentShooter.id],
+      {
+        async onResult() {
+          const existing = await getResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
+          const kills = existing.filter((r) => r.result === ShotResult.KILL).length;
+          setKillCount(kills);
+          setTotalRecorded(existing.length);
+          if (existing.length > 0) {
+            const lastResult = existing[existing.length - 1];
+            const nextTarget = lastResult.target_number;
+            const nextBird = lastResult.bird_number;
+            const maxB = birdsPerTarget(currentStand.target_config as TargetConfig);
+            if (nextBird < maxB) {
+              setTargetNum(nextTarget);
+              setBirdNum(nextBird + 1);
+            } else if (nextTarget < (currentStand.num_targets ?? 0)) {
+              setTargetNum(nextTarget + 1);
+              setBirdNum(1);
+            } else {
+              setTargetNum(nextTarget + 1);
+            }
+          }
+        },
+      },
+      { signal: abort.signal },
+    );
+    return () => abort.abort();
+  }, [db, currentStand?.id, currentShooter?.id]);
+
+  // Load existing results when stand/shooter changes to resume mid-round
+  useEffect(() => {
+    if (!currentStand || !currentShooter) return;
+    (async () => {
+      const existing = await getResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
+      if (existing.length > 0) {
+        const lastResult = existing[existing.length - 1];
+        const kills = existing.filter((r) => r.result === ShotResult.KILL).length;
+        setKillCount(kills);
+        setTotalRecorded(existing.length);
+        const nextTarget = lastResult.target_number;
+        const nextBird = lastResult.bird_number;
+        if (nextBird < maxBirds) {
+          setTargetNum(nextTarget);
+          setBirdNum(nextBird + 1);
+        } else if (nextTarget < (currentStand.num_targets ?? 0)) {
+          setTargetNum(nextTarget + 1);
+          setBirdNum(1);
+        }
+      } else {
+        setKillCount(0);
+        setTotalRecorded(0);
+        setTargetNum(1);
+        setBirdNum(1);
+      }
+    })();
+  }, [currentStand?.id, currentShooter?.id]);
 
   function handleSelectShooter(shooter: ShooterEntry) {
     const idx = shooters.findIndex((s) => s.id === shooter.id);

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -354,6 +354,15 @@ export default function ScoringScreen() {
 
     let standId = createdStandMap.get(clubStand.id);
 
+    // Check if the stand arrived via sync since initial load
+    if (!standId) {
+      const synced = await db.getOptional<{ id: string }>(
+        'SELECT id FROM stands WHERE round_id = ? AND club_stand_id = ?',
+        [roundId, clubStand.id],
+      );
+      if (synced) standId = synced.id;
+    }
+
     // Create the round stand from club template if it doesn't exist yet
     if (!standId) {
       standId = await deterministicUUID(`${roundId}:${clubStand.id}`);

--- a/db/queries/stands.ts
+++ b/db/queries/stands.ts
@@ -16,7 +16,7 @@ export async function createStand(
   },
 ): Promise<void> {
   await db.execute(
-    'INSERT INTO stands (id, round_id, stand_number, target_config, presentation, presentation_notes, num_targets, club_stand_id, club_position_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT OR IGNORE INTO stands (id, round_id, stand_number, target_config, presentation, presentation_notes, num_targets, club_stand_id, club_position_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [params.id, params.round_id, params.stand_number, params.target_config, params.presentation, params.presentation_notes, params.num_targets, params.club_stand_id ?? null, params.club_position_id ?? null],
   );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,8 @@ db/               Database layer
 lib/              Utilities, constants, and types
   types.ts        Domain enums and entity interfaces
   constants.ts    Colours, spacing, presentation labels
+  formatting.ts   Display formatting helpers (stand details, position titles)
+  uuid.ts         Deterministic UUID generation from SHA-256 hashes
   supabase.ts     Supabase client configuration
   powersync-connector.ts  PowerSync ↔ Supabase sync connector
 providers/        React context providers

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ EXPO_PUBLIC_POWERSYNC_URL=https://your-instance.powersync.journeyapps.com
 
 ## Supabase Migrations
 
-The `supabase/migrations/` directory contains 8 migration files that define the full database schema, RLS policies, and seed data:
+The `supabase/migrations/` directory contains migration files that define the full database schema, RLS policies, and seed data:
 
 | Migration | Purpose |
 |-----------|---------|
@@ -47,6 +47,8 @@ The `supabase/migrations/` directory contains 8 migration files that define the 
 | `006_add_invitee_id.sql` | Add `invitee_id` (UUID) to invites |
 | `007_allow_invitee_shooter_entry.sql` | Allow invited users to be added as shooters |
 | `008_allow_squad_scoring.sql` | Allow squad members to record scores |
+| `009_allow_squad_stand_writes.sql` | Allow squad members to write to the stands table |
+| `010_unique_club_stand_per_round.sql` | Unique index preventing duplicate stands per club stand per round |
 
 If setting up a fresh Supabase project, apply these migrations in order. PowerSync sync rules are defined in `supabase/powersync-sync-rules.yaml`.
 

--- a/docs/offline-first.md
+++ b/docs/offline-first.md
@@ -33,6 +33,10 @@ Every entity (rounds, stands, shooters, target results) is assigned a UUID gener
 - Multiple offline devices can create entities without collisions
 - When sync happens, local UUIDs are preserved as the primary keys
 
+### Deterministic UUIDs for Shared Resources
+
+Club round stands are a special case: multiple users may independently try to create the same logical stand. To prevent duplicates, club round stands use **deterministic UUIDs** derived from `SHA-256(round_id + club_stand_id)` via `lib/uuid.ts`. This guarantees that every device generates the same ID for the same logical stand, and `INSERT OR IGNORE` makes the creation idempotent. A partial unique index on `stands(round_id, club_stand_id)` provides a database-level safety net.
+
 ### Current State
 
 The app operates seamlessly offline, while simultaneously utilizing full **PowerSync multi-device synchronization** whenever authenticated users are online. 

--- a/docs/scoring-flow.md
+++ b/docs/scoring-flow.md
@@ -31,6 +31,8 @@ The scoring screen adapts its navigation based on whether the round is custom or
 
 For custom rounds, the state machine advances linearly through stands. For club rounds, the scorer can pick any position and stand in any order.
 
+When a club round scorer selects a stand, the app first checks the local database for a stand that may have arrived via sync from another user. If none exists, it creates one using a deterministic UUID derived from `round_id` and `club_stand_id`, ensuring all devices produce the same stand ID. The insert uses `INSERT OR IGNORE` for idempotency.
+
 ## Birds Per Target
 
 The number of birds per target depends on the stand's target configuration:
@@ -92,7 +94,7 @@ Each tap writes a single `TargetResult` row:
 
 | Field | Value |
 |-------|-------|
-| `id` | New UUID (generated locally via `expo-crypto`) |
+| `id` | New UUID (random for target results, deterministic for club round stands) |
 | `stand_id` | Current stand's ID |
 | `round_id` | Current round's ID (denormalized for efficient querying) |
 | `shooter_entry_id` | Current shooter's ID |
@@ -103,6 +105,19 @@ Each tap writes a single `TargetResult` row:
 | `device_id` | Device identifier for conflict resolution |
 
 All writes go to the local SQLite database. No network call is needed.
+
+## Reactive Sync Updates
+
+The scoring screen uses PowerSync's `db.watch()` to reactively update the UI as data syncs from other devices, without requiring a manual refresh:
+
+| Watcher | Query | Updates |
+|---------|-------|---------|
+| Stands | `stands WHERE round_id = ?` | `createdStandMap` — reflects stands created by other users |
+| Shooter entries | `shooter_entries WHERE squad_id = ?` | `shooters` list — new squad members appear automatically |
+| Shooter statuses | `target_results WHERE stand_id = ?` | Shooter progress badges (not-started / in-progress / completed) |
+| Live score | `target_results WHERE stand_id = ? AND shooter_entry_id = ?` | Kill count and target position for the current shooter |
+
+This means when one user scores a shooter, other users on the same round see the status update in real time.
 
 ## Mid-Round Resume
 

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -1,0 +1,24 @@
+import { CryptoDigestAlgorithm, digestStringAsync } from 'expo-crypto';
+
+/**
+ * Generate a deterministic UUID from an input string.
+ * Uses SHA-256 and formats the first 16 bytes as a UUID v4-shaped string.
+ * Two calls with the same input always produce the same UUID.
+ */
+export async function deterministicUUID(input: string): Promise<string> {
+  const hex = await digestStringAsync(CryptoDigestAlgorithm.SHA256, input);
+
+  // Format first 32 hex chars as UUID: 8-4-4-4-12
+  // Set version nibble (position 12) to 4 and variant bits (position 16) to 8-b
+  const h = hex.slice(0, 32).split('');
+  h[12] = '4'; // version 4
+  h[16] = ((parseInt(h[16], 16) & 0x3) | 0x8).toString(16); // variant 10xx
+
+  return [
+    h.slice(0, 8).join(''),
+    h.slice(8, 12).join(''),
+    h.slice(12, 16).join(''),
+    h.slice(16, 20).join(''),
+    h.slice(20, 32).join(''),
+  ].join('-');
+}

--- a/supabase/migrations/010_unique_club_stand_per_round.sql
+++ b/supabase/migrations/010_unique_club_stand_per_round.sql
@@ -1,0 +1,15 @@
+-- =============================================================
+-- Migration 010: Unique constraint on stands for club rounds
+-- Prevents duplicate stand rows for the same club stand in a round.
+--
+-- Fixes: #60 — Duplicate stand creation race condition
+--
+-- When two squad members select the same club stand before sync,
+-- both may attempt to insert a stand row. The app now uses
+-- deterministic UUIDs so IDs match, but this constraint is a
+-- DB-level safety net for any remaining edge cases.
+-- =============================================================
+
+CREATE UNIQUE INDEX idx_stands_unique_club_stand
+  ON public.stands (round_id, club_stand_id)
+  WHERE club_stand_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Fixes #60 — When multiple users independently select the same club stand during a club round, each device was generating a different random UUID, creating duplicate stand rows. This caused scores to be invisible across users and SQLite UNIQUE constraint errors.

## Changes

### Deterministic UUIDs for club stands
- New `lib/uuid.ts` — generates deterministic UUIDs via `SHA-256(round_id:club_stand_id)` so every device produces the same stand ID for the same logical stand
- `app/round/[id]/score.tsx` — uses `deterministicUUID()` instead of `Crypto.randomUUID()` when creating club round stands

### Idempotent stand creation
- `db/queries/stands.ts` — changed `INSERT INTO` to `INSERT OR IGNORE INTO` as a safety net for TOCTOU races
- `score.tsx` — checks local DB for stands that arrived via sync before attempting creation

### Unique index safety net
- `supabase/migrations/010_unique_club_stand_per_round.sql` — partial unique index on `stands(round_id, club_stand_id)` preventing duplicates at the database level

### Real-time sync updates (no manual refresh needed)
- **Stands watcher** — `createdStandMap` updates reactively when other users create stands via sync
- **Shooter entries watcher** — new squad members appear automatically when they accept invites
- **Shooter statuses watcher** — progress badges update in real time as scores sync
- **Live score watcher** — kill count and target position update as another user scores

### Documentation
- Updated `getting-started.md`, `architecture.md`, `offline-first.md`, and `scoring-flow.md` to reflect all changes