### PR TITLE
Fix iOS crash from missing QuickSQLite

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "@journeyapps/react-native-quick-sqlite"
     ],
     "experiments": {
       "typedRoutes": true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 | Mobile Framework | React Native + Expo (managed workflow) | RN 0.83, Expo 55 |
 | Language | TypeScript | 5.9 |
 | Routing | Expo Router (file-based) | 55.0 |
-| Local Database | SQLite via PowerSync | — |
+| Local Database | SQLite via PowerSync (`react-native-quick-sqlite` on native, `wa-sqlite` on web) | — |
 | Sync Engine | PowerSync | web 1.34, native 1.30 |
 | Backend | Supabase (PostgreSQL + Auth) | 2.49 |
 | Build & Deploy | Expo EAS Build | — |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 - **Node.js** 18+ and npm
 - **Expo CLI** (`npx expo` — no global install needed)
 - A web browser for development (Chrome recommended)
-- For native development: Xcode (iOS) or Android Studio (Android), or use Expo Go on a physical device
+- For native development: Xcode (iOS) or Android Studio (Android) — native builds are required because the app uses native modules (e.g. `@journeyapps/react-native-quick-sqlite`) that are not available in Expo Go
 
 ## Setup
 
@@ -68,7 +68,7 @@ Opens at `http://localhost:8081`. Hot reload is enabled.
 npm run ios
 ```
 
-Requires Xcode, or use Expo Go on a physical iPhone.
+Runs `expo run:ios`, which builds a development client with native modules. Requires Xcode. The first build takes several minutes; subsequent launches are fast.
 
 ### Android
 
@@ -76,7 +76,7 @@ Requires Xcode, or use Expo Go on a physical iPhone.
 npm run android
 ```
 
-Requires Android Studio with an emulator, or use Expo Go on a physical Android device.
+Runs `expo run:android`, which builds a development client with native modules. Requires Android Studio with an emulator or a connected device.
 
 ## Project Scripts
 
@@ -84,8 +84,8 @@ Requires Android Studio with an emulator, or use Expo Go on a physical Android d
 |--------|---------|---------|
 | `start` | `expo start` | Start dev server (pick platform interactively) |
 | `web` | `expo start --web` | Start web dev server |
-| `ios` | `expo start --ios` | Start iOS dev server |
-| `android` | `expo start --android` | Start Android dev server |
+| `ios` | `expo run:ios` | Build and run native iOS dev client |
+| `android` | `expo run:android` | Build and run native Android dev client |
 | `postinstall` | `npx powersync-web copy-assets --output public` | Copy WASM assets for web |
 
 ## Common Issues

--- a/docs/offline-first.md
+++ b/docs/offline-first.md
@@ -50,7 +50,7 @@ PowerSync uses different packages for web browsers and native platforms (iOS/And
 | Platform | Package | SQLite Engine |
 |----------|---------|---------------|
 | Web | `@powersync/web` | wa-sqlite (WASM) |
-| iOS / Android | `@powersync/react-native` | Native SQLite |
+| iOS / Android | `@powersync/react-native` | `@journeyapps/react-native-quick-sqlite` |
 
 The app handles this with platform-specific file extensions, which Metro and Expo resolve automatically:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "score-my-clays",
       "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@journeyapps/react-native-quick-sqlite": "^2.5.1",
         "@journeyapps/wa-sqlite": "^1.5.0",
         "@powersync/react-native": "^1.30.2",
         "@powersync/web": "^1.34.0",
@@ -2069,6 +2071,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@journeyapps/react-native-quick-sqlite": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-2.5.1.tgz",
+      "integrity": "sha512-LDSR8j86bzvoogg1HMprnS4g6Tx0ySNBeKvrCwvhWSyY3H9L4FpU5zMV2S4NEjn3RYk2/klcCc0KB/eyITgwPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@journeyapps/wa-sqlite": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "private": true,
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "postinstall": "npx powersync-web copy-assets --output public && cp node_modules/@journeyapps/wa-sqlite/dist/wa-sqlite-async.wasm public/"
   },
   "dependencies": {
+    "@journeyapps/react-native-quick-sqlite": "^2.5.1",
     "@journeyapps/wa-sqlite": "^1.5.0",
     "@powersync/react-native": "^1.30.2",
     "@powersync/web": "^1.34.0",


### PR DESCRIPTION
## Summary

- Add `@journeyapps/react-native-quick-sqlite` — required by `@powersync/react-native` for native SQLite operations
- Update `ios`/`android` scripts to use `expo run:*` since native dependencies require development builds
- Expo auto-registered the package as a config plugin in `app.json`

## Context

The app crashed immediately on iOS because PowerSync tries to `require('@journeyapps/react-native-quick-sqlite')` at startup. It's listed as an optional peer dep but is actually required for native (iOS/Android). Web was unaffected (uses `wa-sqlite`).

Closes #69

## Test plan

- [x] `npx expo run:ios` — app launches, QuickSQLite module installs successfully
- [x] Database initializes (home screen loads, no error banners)
- [x] `npx expo start --web` — confirm web still works