### PR TITLE
Prefix app-level db functions and files with smc namespace (#70)

### DIFF
--- a/__tests__/db/queries/clubs.test.ts
+++ b/__tests__/db/queries/clubs.test.ts
@@ -1,5 +1,5 @@
 import { createMockDb } from '../../helpers/mockDb';
-import { listClubs, getClubWithDetails } from '@/db/queries/clubs';
+import { smcListClubs, smcGetClubWithDetails } from '@/db/queries/smc-clubs';
 import type { Club, ClubPosition, ClubStand } from '@/lib/types';
 import { TargetConfig, PresentationType } from '@/lib/types';
 
@@ -11,12 +11,12 @@ const mockClub: Club = {
   created_at: '2026-01-01T00:00:00Z',
 };
 
-describe('listClubs', () => {
+describe('smcListClubs', () => {
   it('filters by search term when provided', async () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([mockClub]);
 
-    await listClubs(db, 'Test');
+    await smcListClubs(db, 'Test');
 
     const [sql, params] = (db.getAll as jest.Mock).mock.calls[0];
     expect(sql).toContain('LIKE ?');
@@ -27,7 +27,7 @@ describe('listClubs', () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([mockClub]);
 
-    await listClubs(db);
+    await smcListClubs(db);
 
     const [sql, params] = (db.getAll as jest.Mock).mock.calls[0];
     expect(sql).not.toContain('LIKE');
@@ -38,19 +38,19 @@ describe('listClubs', () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([]);
 
-    await listClubs(db, '   ');
+    await smcListClubs(db, '   ');
 
     const [sql] = (db.getAll as jest.Mock).mock.calls[0];
     expect(sql).not.toContain('LIKE');
   });
 });
 
-describe('getClubWithDetails', () => {
+describe('smcGetClubWithDetails', () => {
   it('returns null when club not found', async () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue(null);
 
-    const result = await getClubWithDetails(db, 'missing');
+    const result = await smcGetClubWithDetails(db, 'missing');
     expect(result).toBeNull();
   });
 
@@ -79,7 +79,7 @@ describe('getClubWithDetails', () => {
       .mockResolvedValueOnce([position])
       .mockResolvedValueOnce([stand]);
 
-    const result = await getClubWithDetails(db, 'club1');
+    const result = await smcGetClubWithDetails(db, 'club1');
 
     expect(result).not.toBeNull();
     expect(result!.club).toEqual(mockClub);

--- a/__tests__/db/queries/invites.test.ts
+++ b/__tests__/db/queries/invites.test.ts
@@ -1,5 +1,5 @@
 import { createMockDb } from '../../helpers/mockDb';
-import { checkDuplicateInvite, listIncomingInvitesForUser } from '@/db/queries/invites';
+import { smcCheckDuplicateInvite, smcListIncomingInvitesForUser } from '@/db/queries/smc-invites';
 import { InviteStatus, type Invite } from '@/lib/types';
 
 const mockInvite: Invite = {
@@ -12,12 +12,12 @@ const mockInvite: Invite = {
   created_at: '2026-01-01T00:00:00Z',
 };
 
-describe('checkDuplicateInvite', () => {
+describe('smcCheckDuplicateInvite', () => {
   it('returns existing invite when duplicate found', async () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue(mockInvite);
 
-    const result = await checkDuplicateInvite(db, 'round1', '@phil');
+    const result = await smcCheckDuplicateInvite(db, 'round1', '@phil');
 
     expect(result).toEqual(mockInvite);
     expect(db.getOptional).toHaveBeenCalledWith(
@@ -30,17 +30,17 @@ describe('checkDuplicateInvite', () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue(null);
 
-    const result = await checkDuplicateInvite(db, 'round1', '@new_user');
+    const result = await smcCheckDuplicateInvite(db, 'round1', '@new_user');
     expect(result).toBeNull();
   });
 });
 
-describe('listIncomingInvitesForUser', () => {
+describe('smcListIncomingInvitesForUser', () => {
   it('filters by status when provided', async () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([mockInvite]);
 
-    await listIncomingInvitesForUser(db, '@phil', InviteStatus.PENDING);
+    await smcListIncomingInvitesForUser(db, '@phil', InviteStatus.PENDING);
 
     const [sql, params] = (db.getAll as jest.Mock).mock.calls[0];
     expect(sql).toContain('status = ?');
@@ -51,7 +51,7 @@ describe('listIncomingInvitesForUser', () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([mockInvite]);
 
-    await listIncomingInvitesForUser(db, '@phil');
+    await smcListIncomingInvitesForUser(db, '@phil');
 
     const [sql, params] = (db.getAll as jest.Mock).mock.calls[0];
     expect(sql).not.toContain('status = ?');

--- a/__tests__/db/queries/scoring.test.ts
+++ b/__tests__/db/queries/scoring.test.ts
@@ -1,10 +1,10 @@
 import { createMockDb } from '../../helpers/mockDb';
 import {
-  getResultsForStandAndShooter,
-  getShooterRoundScore,
-  getRoundConflicts,
-  resolveConflict,
-} from '@/db/queries/scoring';
+  smcGetResultsForStandAndShooter,
+  smcGetShooterRoundScore,
+  smcGetRoundConflicts,
+  smcResolveConflict,
+} from '@/db/queries/smc-scoring';
 import type { TargetResultRecord } from '@/lib/types';
 import { ShotResult } from '@/lib/types';
 
@@ -23,7 +23,7 @@ function makeResult(overrides: Partial<TargetResultRecord> = {}): TargetResultRe
   };
 }
 
-describe('getResultsForStandAndShooter', () => {
+describe('smcGetResultsForStandAndShooter', () => {
   it('deduplicates by keeping first occurrence per target/bird', async () => {
     const db = createMockDb();
     const rows: TargetResultRecord[] = [
@@ -33,7 +33,7 @@ describe('getResultsForStandAndShooter', () => {
     ];
     (db.getAll as jest.Mock).mockResolvedValue(rows);
 
-    const result = await getResultsForStandAndShooter(db, 's1', 'se1');
+    const result = await smcGetResultsForStandAndShooter(db, 's1', 'se1');
 
     expect(result).toHaveLength(2);
     expect(result[0].id).toBe('r1');
@@ -49,19 +49,19 @@ describe('getResultsForStandAndShooter', () => {
     ];
     (db.getAll as jest.Mock).mockResolvedValue(rows);
 
-    const result = await getResultsForStandAndShooter(db, 's1', 'se1');
+    const result = await smcGetResultsForStandAndShooter(db, 's1', 'se1');
     expect(result).toHaveLength(3);
   });
 });
 
-describe('getShooterRoundScore', () => {
+describe('smcGetShooterRoundScore', () => {
   it('returns zero kills and total when conflicts exist', async () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock)
       .mockResolvedValueOnce({ conflict_count: 2 })
       .mockResolvedValueOnce({ kills: 5, total: 10 });
 
-    const result = await getShooterRoundScore(db, 'round1', 'se1');
+    const result = await smcGetShooterRoundScore(db, 'round1', 'se1');
 
     expect(result).toEqual({ kills: 0, total: 0, hasConflicts: true });
   });
@@ -72,7 +72,7 @@ describe('getShooterRoundScore', () => {
       .mockResolvedValueOnce({ conflict_count: 0 })
       .mockResolvedValueOnce({ kills: 7, total: 10 });
 
-    const result = await getShooterRoundScore(db, 'round1', 'se1');
+    const result = await smcGetShooterRoundScore(db, 'round1', 'se1');
 
     expect(result).toEqual({ kills: 7, total: 10, hasConflicts: false });
   });
@@ -83,18 +83,18 @@ describe('getShooterRoundScore', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
 
-    const result = await getShooterRoundScore(db, 'round1', 'se1');
+    const result = await smcGetShooterRoundScore(db, 'round1', 'se1');
 
     expect(result).toEqual({ kills: 0, total: 0, hasConflicts: false });
   });
 });
 
-describe('getRoundConflicts', () => {
+describe('smcGetRoundConflicts', () => {
   it('returns empty array when no conflicts', async () => {
     const db = createMockDb();
     (db.getAll as jest.Mock).mockResolvedValue([]);
 
-    const result = await getRoundConflicts(db, 'round1');
+    const result = await smcGetRoundConflicts(db, 'round1');
     expect(result).toEqual([]);
   });
 
@@ -110,7 +110,7 @@ describe('getRoundConflicts', () => {
       .mockResolvedValueOnce(dupes)
       .mockResolvedValueOnce(allResults);
 
-    const result = await getRoundConflicts(db, 'round1');
+    const result = await smcGetRoundConflicts(db, 'round1');
 
     expect(result).toHaveLength(1);
     expect(result[0].records).toHaveLength(2);
@@ -119,7 +119,7 @@ describe('getRoundConflicts', () => {
   });
 });
 
-describe('resolveConflict', () => {
+describe('smcResolveConflict', () => {
   it('deletes specified IDs in a transaction', async () => {
     const db = createMockDb();
     const txExecute = jest.fn().mockResolvedValue(undefined);
@@ -127,7 +127,7 @@ describe('resolveConflict', () => {
       await cb({ execute: txExecute });
     });
 
-    await resolveConflict(db, 'keep1', ['del1', 'del2']);
+    await smcResolveConflict(db, 'keep1', ['del1', 'del2']);
 
     expect(txExecute).toHaveBeenCalledTimes(2);
     expect(txExecute).toHaveBeenCalledWith('DELETE FROM target_results WHERE id = ?', ['del1']);

--- a/__tests__/db/queries/stands.test.ts
+++ b/__tests__/db/queries/stands.test.ts
@@ -1,12 +1,12 @@
 import { createMockDb } from '../../helpers/mockDb';
-import { updateStand } from '@/db/queries/stands';
+import { smcUpdateStand } from '@/db/queries/smc-stands';
 import { TargetConfig, PresentationType } from '@/lib/types';
 
-describe('updateStand', () => {
+describe('smcUpdateStand', () => {
   it('builds dynamic SQL for partial updates', async () => {
     const db = createMockDb();
 
-    await updateStand(db, 'stand1', {
+    await smcUpdateStand(db, 'stand1', {
       num_targets: 5,
       presentation: PresentationType.DRIVEN,
     });
@@ -23,7 +23,7 @@ describe('updateStand', () => {
   it('does not execute when no params provided', async () => {
     const db = createMockDb();
 
-    await updateStand(db, 'stand1', {});
+    await smcUpdateStand(db, 'stand1', {});
 
     expect(db.execute).not.toHaveBeenCalled();
   });
@@ -31,7 +31,7 @@ describe('updateStand', () => {
   it('handles single field update', async () => {
     const db = createMockDb();
 
-    await updateStand(db, 'stand1', { target_config: TargetConfig.REPORT_PAIR });
+    await smcUpdateStand(db, 'stand1', { target_config: TargetConfig.REPORT_PAIR });
 
     const [sql, params] = (db.execute as jest.Mock).mock.calls[0];
     expect(sql).toBe('UPDATE stands SET target_config = ? WHERE id = ?');

--- a/__tests__/db/queries/users.test.ts
+++ b/__tests__/db/queries/users.test.ts
@@ -1,12 +1,12 @@
 import { createMockDb } from '../../helpers/mockDb';
-import { isUserIdAvailable, updateUserProfile } from '@/db/queries/users';
+import { smcIsUserIdAvailable, smcUpdateUserProfile } from '@/db/queries/smc-users';
 
-describe('isUserIdAvailable', () => {
+describe('smcIsUserIdAvailable', () => {
   it('returns true when user_id is not taken', async () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue({ count: 0 });
 
-    const available = await isUserIdAvailable(db, 'new_handle');
+    const available = await smcIsUserIdAvailable(db, 'new_handle');
 
     expect(available).toBe(true);
     const [sql] = (db.getOptional as jest.Mock).mock.calls[0];
@@ -17,7 +17,7 @@ describe('isUserIdAvailable', () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue({ count: 1 });
 
-    const available = await isUserIdAvailable(db, 'existing_handle');
+    const available = await smcIsUserIdAvailable(db, 'existing_handle');
     expect(available).toBe(false);
   });
 
@@ -25,16 +25,16 @@ describe('isUserIdAvailable', () => {
     const db = createMockDb();
     (db.getOptional as jest.Mock).mockResolvedValue(null);
 
-    const available = await isUserIdAvailable(db, 'any_handle');
+    const available = await smcIsUserIdAvailable(db, 'any_handle');
     expect(available).toBe(true);
   });
 });
 
-describe('updateUserProfile', () => {
+describe('smcUpdateUserProfile', () => {
   it('builds dynamic SQL for multiple fields', async () => {
     const db = createMockDb();
 
-    await updateUserProfile(db, 'user1', {
+    await smcUpdateUserProfile(db, 'user1', {
       display_name: 'New Name',
       discoverable: 1,
     });
@@ -55,7 +55,7 @@ describe('updateUserProfile', () => {
   it('does not execute when no fields provided', async () => {
     const db = createMockDb();
 
-    await updateUserProfile(db, 'user1', {});
+    await smcUpdateUserProfile(db, 'user1', {});
 
     expect(db.execute).not.toHaveBeenCalled();
   });

--- a/app/(tabs)/clubs.tsx
+++ b/app/(tabs)/clubs.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
-import { listClubs } from '@/db/queries/clubs';
+import { smcListClubs } from '@/db/queries/smc-clubs';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import LoadingPlaceholder from '@/components/LoadingPlaceholder';
 import type { Club } from '@/lib/types';
@@ -22,7 +22,7 @@ export default function ClubsScreen() {
   const [isLoading, setIsLoading] = useState(true);
 
   const loadClubs = useCallback(async () => {
-    const results = await listClubs(db, search || undefined);
+    const results = await smcListClubs(db, search || undefined);
     setClubs(results);
     setIsLoading(false);
   }, [db, search]);

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -9,7 +9,7 @@ import {
 import { useRouter, useFocusEffect } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
 import { useAuth } from '@/providers/AuthProvider';
-import { listRounds } from '@/db/queries/rounds';
+import { smcListRounds } from '@/db/queries/smc-rounds';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import { RoundStatus, type Round } from '@/lib/types';
 
@@ -28,7 +28,7 @@ export default function HistoryScreen() {
   useFocusEffect(
     useCallback(() => {
       if (!user) return;
-      listRounds(db, user.id).then(setRounds);
+      smcListRounds(db, user.id).then(setRounds);
     }, [db, user]),
   );
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,8 +9,8 @@ import {
 import { useRouter, useFocusEffect } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
 import { useAuth } from '@/providers/AuthProvider';
-import { listRounds } from '@/db/queries/rounds';
-import { listIncomingInvitesForUser } from '@/db/queries/invites';
+import { smcListRounds } from '@/db/queries/smc-rounds';
+import { smcListIncomingInvitesForUser } from '@/db/queries/smc-invites';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import { RoundStatus, InviteStatus, type Round } from '@/lib/types';
 
@@ -24,9 +24,9 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       if (!user) return;
-      listRounds(db, user.id).then((all) => setRecent(all.slice(0, 5)));
+      smcListRounds(db, user.id).then((all) => setRecent(all.slice(0, 5)));
       if (user.user_id) {
-        listIncomingInvitesForUser(db, user.user_id, InviteStatus.PENDING)
+        smcListIncomingInvitesForUser(db, user.user_id, InviteStatus.PENDING)
           .then((invites) => setPendingInviteCount(invites.length));
       }
     }, [db, user]),

--- a/app/(tabs)/new-round.tsx
+++ b/app/(tabs)/new-round.tsx
@@ -13,7 +13,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { useAuth } from '@/providers/AuthProvider';
-import { listClubs, getClub } from '@/db/queries/clubs';
+import { smcListClubs, smcGetClub } from '@/db/queries/smc-clubs';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import type { Club } from '@/lib/types';
 
@@ -37,7 +37,7 @@ export default function NewRoundScreen() {
   useEffect(() => {
     if (params.clubId) {
       (async () => {
-        const club = await getClub(db, params.clubId!);
+        const club = await smcGetClub(db, params.clubId!);
         if (club) {
           setSelectedClub(club);
           setClubSearch(club.name);
@@ -54,7 +54,7 @@ export default function NewRoundScreen() {
       setShowClubDropdown(false);
       return;
     }
-    const results = await listClubs(db, query);
+    const results = await smcListClubs(db, query);
     setClubResults(results);
     setShowClubDropdown(results.length > 0);
   }, [db]);

--- a/app/auth/profile-setup.tsx
+++ b/app/auth/profile-setup.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/providers/AuthProvider';
 import { usePowerSync } from '@powersync/react';
 import { Colors } from '@/lib/constants';
 import type { Club } from '@/lib/types';
-import { updateUserProfile, isUserIdAvailable } from '@/db/queries/users';
+import { smcUpdateUserProfile, smcIsUserIdAvailable } from '@/db/queries/smc-users';
 
 export default function ProfileSetupScreen() {
   const { user, signOut, refreshUser } = useAuth();
@@ -69,7 +69,7 @@ export default function ProfileSetupScreen() {
 
     setCheckingUserId(true);
     try {
-      const available = await isUserIdAvailable(db, userId);
+      const available = await smcIsUserIdAvailable(db, userId);
       setUserIdAvailable(available);
     } catch (err) {
       console.error('Error checking userId:', err);
@@ -120,7 +120,7 @@ export default function ProfileSetupScreen() {
     setLoading(true);
 
     try {
-      await updateUserProfile(db, user.id, {
+      await smcUpdateUserProfile(db, user.id, {
         display_name: displayName,
         user_id: userId,
         discoverable: discoverable ? 1 : 0,

--- a/app/clubs/[id]/index.tsx
+++ b/app/clubs/[id]/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
-import { getClubWithDetails } from '@/db/queries/clubs';
+import { smcGetClubWithDetails } from '@/db/queries/smc-clubs';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import { formatStandDetail, formatPositionTitle } from '@/lib/formatting';
 import LoadingPlaceholder from '@/components/LoadingPlaceholder';
@@ -25,7 +25,7 @@ export default function ClubDetailScreen() {
 
   const load = useCallback(async () => {
     if (!clubId) return;
-    const result = await getClubWithDetails(db, clubId);
+    const result = await smcGetClubWithDetails(db, clubId);
     if (result) {
       setClub(result.club);
       setPositions(result.positions);

--- a/app/invites/index.tsx
+++ b/app/invites/index.tsx
@@ -18,13 +18,13 @@ import { useAuth } from '@/providers/AuthProvider';
 import { Colors } from '@/lib/constants';
 import { InviteStatus, RoundStatus, type Invite, type User, type Round } from '@/lib/types';
 import {
-  listIncomingInvitesForUser,
-  updateInviteStatus,
-} from '@/db/queries/invites';
-import { getUserById } from '@/db/queries/users';
-import { getRound } from '@/db/queries/rounds';
+  smcListIncomingInvitesForUser,
+  smcUpdateInviteStatus,
+} from '@/db/queries/smc-invites';
+import { smcGetUserById } from '@/db/queries/smc-users';
+import { smcGetRound } from '@/db/queries/smc-rounds';
 import * as Crypto from 'expo-crypto';
-import { addShooterEntry, getSquadByRound } from '@/db/queries/squads';
+import { smcAddShooterEntry, smcGetSquadByRound } from '@/db/queries/smc-squads';
 
 export default function InvitesScreen() {
   const { user } = useAuth();
@@ -41,7 +41,7 @@ export default function InvitesScreen() {
     if (!user?.user_id) return;
 
     try {
-      const pendingInvites = await listIncomingInvitesForUser(
+      const pendingInvites = await smcListIncomingInvitesForUser(
         db,
         user.user_id,
         InviteStatus.PENDING
@@ -52,7 +52,7 @@ export default function InvitesScreen() {
       const details: Record<string, { inviter: User | null; round: Round | null }> = {};
       for (const invite of pendingInvites) {
         try {
-          const inviter = await getUserById(db, invite.inviter_id);
+          const inviter = await smcGetUserById(db, invite.inviter_id);
           const round = await db.getOptional<Round>(
             'SELECT * FROM rounds WHERE id = ?',
             [invite.round_id]
@@ -82,7 +82,7 @@ export default function InvitesScreen() {
   const handleAcceptInvite = async (invite: Invite) => {
     try {
       // Get the squad for this round
-      const squad = await getSquadByRound(db, invite.round_id);
+      const squad = await smcGetSquadByRound(db, invite.round_id);
       if (!squad) {
         if (Platform.OS === 'web') window.alert('Could not find squad for this round');
         else Alert.alert('Error', 'Could not find squad for this round');
@@ -109,7 +109,7 @@ export default function InvitesScreen() {
       const nextPosition = (maxPosition?.max_pos || 0) + 1;
 
       // Create shooter entry with user's UUID (not handle) so sync rules match
-      await addShooterEntry(db, {
+      await smcAddShooterEntry(db, {
         id: Crypto.randomUUID(),
         squad_id: squad.id,
         round_id: invite.round_id,
@@ -119,10 +119,10 @@ export default function InvitesScreen() {
       });
 
       // Update invite status
-      await updateInviteStatus(db, invite.id, InviteStatus.ACCEPTED);
+      await smcUpdateInviteStatus(db, invite.id, InviteStatus.ACCEPTED);
 
       // Route based on round status: in-progress → scoring, completed → summary
-      const round = await getRound(db, invite.round_id);
+      const round = await smcGetRound(db, invite.round_id);
       const destination = round?.status === RoundStatus.IN_PROGRESS
         ? `/round/${invite.round_id}/score`
         : `/round/${invite.round_id}/summary`;
@@ -150,7 +150,7 @@ export default function InvitesScreen() {
 
   const handleDeclineInvite = async (inviteId: string) => {
     try {
-      await updateInviteStatus(db, inviteId, InviteStatus.DECLINED);
+      await smcUpdateInviteStatus(db, inviteId, InviteStatus.DECLINED);
       if (Platform.OS === 'web') window.alert('Invite declined');
       else Alert.alert('Success', 'Invite declined');
       loadInvites();

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/providers/AuthProvider';
 import { usePowerSync } from '@powersync/react';
 import { Colors } from '@/lib/constants';
 import type { Club } from '@/lib/types';
-import { updateUserProfile } from '@/db/queries/users';
+import { smcUpdateUserProfile } from '@/db/queries/smc-users';
 
 export default function EditProfileScreen() {
   const router = useRouter();
@@ -71,7 +71,7 @@ export default function EditProfileScreen() {
     setLoading(true);
 
     try {
-      await updateUserProfile(db, user.id, {
+      await smcUpdateUserProfile(db, user.id, {
         display_name: displayName,
         discoverable: discoverable ? 1 : 0,
         favourite_club_ids: JSON.stringify(selectedClubIds),

--- a/app/round/[id]/conflicts.tsx
+++ b/app/round/[id]/conflicts.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
-import { getRoundConflicts, resolveConflict, type ConflictedShotGroup } from '@/db/queries/scoring';
-import { getRound } from '@/db/queries/rounds';
-import { getSquadByRound, listShooterEntries } from '@/db/queries/squads';
+import { smcGetRoundConflicts, smcResolveConflict, type ConflictedShotGroup } from '@/db/queries/smc-scoring';
+import { smcGetRound } from '@/db/queries/smc-rounds';
+import { smcGetSquadByRound, smcListShooterEntries } from '@/db/queries/smc-squads';
 import { useAuth } from '@/providers/AuthProvider';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import LoadingPlaceholder from '@/components/LoadingPlaceholder';
@@ -32,22 +32,22 @@ export default function ConflictsScreen() {
     if (!roundId) return;
     
     // Authorization check
-    const round = await getRound(db, roundId);
+    const round = await smcGetRound(db, roundId);
     if (!round || round.created_by !== user?.id) {
       Alert.alert('Unauthorized', 'Only the round organizer can resolve conflicts.');
       router.back();
       return;
     }
 
-    const squad = await getSquadByRound(db, roundId);
+    const squad = await smcGetSquadByRound(db, roundId);
     if (squad) {
-      const shooterList = await listShooterEntries(db, squad.id);
+      const shooterList = await smcListShooterEntries(db, squad.id);
       const shooterMap: Record<string, ShooterEntry> = {};
       shooterList.forEach(s => { shooterMap[s.id] = s; });
       setShooters(shooterMap);
     }
 
-    const c = await getRoundConflicts(db, roundId);
+    const c = await smcGetRoundConflicts(db, roundId);
     setConflicts(c);
     setIsLoading(false);
   }
@@ -69,7 +69,7 @@ export default function ConflictsScreen() {
         const keepId = resolved[groupKey];
         if (keepId) {
           const deleteIds = group.records.filter(r => r.id !== keepId).map(r => r.id);
-          await resolveConflict(db, keepId, deleteIds);
+          await smcResolveConflict(db, keepId, deleteIds);
         }
       }
       Alert.alert('Success', 'All conflicts resolved!');

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -14,12 +14,12 @@ import * as Crypto from 'expo-crypto';
 import { Ionicons } from '@expo/vector-icons';
 import { deterministicUUID } from '@/lib/uuid';
 import { useAuth } from '@/providers/AuthProvider';
-import { getRound } from '@/db/queries/rounds';
-import { getSquadByRound, listShooterEntriesWithUsers } from '@/db/queries/squads';
-import { listStands, createStand } from '@/db/queries/stands';
-import { recordTargetResult, getResultsForStandAndShooter, getRoundConflicts, type ConflictedShotGroup } from '@/db/queries/scoring';
-import { updateRoundStatus } from '@/db/queries/rounds';
-import { getClubWithDetails } from '@/db/queries/clubs';
+import { smcGetRound } from '@/db/queries/smc-rounds';
+import { smcGetSquadByRound, smcListShooterEntriesWithUsers } from '@/db/queries/smc-squads';
+import { smcListStands, smcCreateStand } from '@/db/queries/smc-stands';
+import { smcRecordTargetResult, smcGetResultsForStandAndShooter, smcGetRoundConflicts, type ConflictedShotGroup } from '@/db/queries/smc-scoring';
+import { smcUpdateRoundStatus } from '@/db/queries/smc-rounds';
+import { smcGetClubWithDetails } from '@/db/queries/smc-clubs';
 import { Colors, Spacing, FontSize, BorderRadius, PRESENTATION_LABELS } from '@/lib/constants';
 import LoadingPlaceholder from '@/components/LoadingPlaceholder';
 import PositionPicker, { type PositionStatus } from '@/components/PositionPicker';
@@ -91,23 +91,23 @@ export default function ScoringScreen() {
   useEffect(() => {
     (async () => {
       if (!roundId) return;
-      const r = await getRound(db, roundId);
+      const r = await smcGetRound(db, roundId);
       setRound(r);
 
-      const squad = await getSquadByRound(db, roundId);
+      const squad = await smcGetSquadByRound(db, roundId);
       if (squad) {
         setSquadId(squad.id);
-        const entries = await listShooterEntriesWithUsers(db, squad.id);
+        const entries = await smcListShooterEntriesWithUsers(db, squad.id);
         setShooters(entries);
       }
 
       if (r?.club_id) {
-        const clubData = await getClubWithDetails(db, r.club_id);
+        const clubData = await smcGetClubWithDetails(db, r.club_id);
         if (clubData) {
           setClubPositions(clubData.positions);
         }
         // Load existing stands (for resume)
-        const existingStands = await listStands(db, roundId);
+        const existingStands = await smcListStands(db, roundId);
         const standMap = new Map<string, string>();
         for (const s of existingStands) {
           if (s.club_stand_id) {
@@ -119,7 +119,7 @@ export default function ScoringScreen() {
       }
 
       // Load conflicts for this round
-      const c = await getRoundConflicts(db, roundId);
+      const c = await smcGetRoundConflicts(db, roundId);
       setConflicts(c);
 
       setIsLoading(false);
@@ -156,7 +156,7 @@ export default function ScoringScreen() {
       const totalShots = (stand.num_targets ?? 0) * birdsPerTarget(stand.target_config as TargetConfig);
 
       for (const shooter of shooters) {
-        const results = await getResultsForStandAndShooter(db, stand.id, shooter.id);
+        const results = await smcGetResultsForStandAndShooter(db, stand.id, shooter.id);
         const recorded = results.length;
         progress[shooter.id] = { recorded, total: totalShots };
         if (recorded === 0) {
@@ -227,7 +227,7 @@ export default function ScoringScreen() {
       [currentStand.id, currentShooter.id],
       {
         async onResult() {
-          const existing = await getResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
+          const existing = await smcGetResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
           const kills = existing.filter((r) => r.result === ShotResult.KILL).length;
           setKillCount(kills);
           setTotalRecorded(existing.length);
@@ -257,7 +257,7 @@ export default function ScoringScreen() {
   useEffect(() => {
     if (!currentStand || !currentShooter) return;
     (async () => {
-      const existing = await getResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
+      const existing = await smcGetResultsForStandAndShooter(db, currentStand.id, currentShooter.id);
       if (existing.length > 0) {
         const lastResult = existing[existing.length - 1];
         const kills = existing.filter((r) => r.result === ShotResult.KILL).length;
@@ -357,7 +357,7 @@ export default function ScoringScreen() {
       if (!currentStand || !currentShooter || !user || standComplete) return;
       triggerHaptic();
 
-      await recordTargetResult(db, {
+      await smcRecordTargetResult(db, {
         id: Crypto.randomUUID(),
         stand_id: currentStand.id,
         round_id: roundId!,
@@ -406,7 +406,7 @@ export default function ScoringScreen() {
     // Create the round stand from club template if it doesn't exist yet
     if (!standId) {
       standId = await deterministicUUID(`${roundId}:${clubStand.id}`);
-      await createStand(db, {
+      await smcCreateStand(db, {
         id: standId,
         round_id: roundId,
         stand_number: clubStand.stand_number,
@@ -455,7 +455,7 @@ export default function ScoringScreen() {
   }
   async function handleFinish() {
     if (!roundId) return;
-    await updateRoundStatus(db, roundId, RoundStatus.COMPLETED);
+    await smcUpdateRoundStatus(db, roundId, RoundStatus.COMPLETED);
     router.replace(`/round/${roundId}/summary`);
   }
 

--- a/app/round/[id]/setup.tsx
+++ b/app/round/[id]/setup.tsx
@@ -12,11 +12,11 @@ import {
 import { usePowerSync, useQuery } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { useAuth } from '@/providers/AuthProvider';
-import { getRound } from '@/db/queries/rounds';
-import { getSquadByRound, addShooterEntry, listShooterEntries, removeShooterEntry } from '@/db/queries/squads';
-import { getClubWithDetails } from '@/db/queries/clubs';
-import { createInvite, checkDuplicateInvite } from '@/db/queries/invites';
-import { getUserByUserId } from '@/db/queries/users';
+import { smcGetRound } from '@/db/queries/smc-rounds';
+import { smcGetSquadByRound, smcAddShooterEntry, smcListShooterEntries, smcRemoveShooterEntry } from '@/db/queries/smc-squads';
+import { smcGetClubWithDetails } from '@/db/queries/smc-clubs';
+import { smcCreateInvite, smcCheckDuplicateInvite } from '@/db/queries/smc-invites';
+import { smcGetUserByUserId } from '@/db/queries/smc-users';
 import { Colors, Spacing, FontSize, BorderRadius, MAX_SQUAD_SIZE } from '@/lib/constants';
 import { formatStandDetail, formatPositionTitle } from '@/lib/formatting';
 import { InviteStatus, type ShooterEntry, type Round, type PositionWithStands, type User } from '@/lib/types';
@@ -43,21 +43,21 @@ export default function RoundSetupScreen() {
 
   const reload = useCallback(async () => {
     if (!roundId) return;
-    const r = await getRound(db, roundId);
+    const r = await smcGetRound(db, roundId);
     setRound(r);
 
     // Load club positions
     if (r?.club_id) {
-      const clubData = await getClubWithDetails(db, r.club_id);
+      const clubData = await smcGetClubWithDetails(db, r.club_id);
       if (clubData) {
         setClubPositions(clubData.positions);
       }
     }
 
-    const squad = await getSquadByRound(db, roundId);
+    const squad = await smcGetSquadByRound(db, roundId);
     if (squad) {
       setSquadId(squad.id);
-      const entries = await listShooterEntries(db, squad.id);
+      const entries = await smcListShooterEntries(db, squad.id);
       setShooters(entries);
     }
   }, [db, roundId]);
@@ -72,7 +72,7 @@ export default function RoundSetupScreen() {
     if (!user || !roundId) return;
 
     // Check if already invited or participant
-    const existing = await checkDuplicateInvite(db, roundId, selectedUser.user_id!);
+    const existing = await smcCheckDuplicateInvite(db, roundId, selectedUser.user_id!);
     if (existing) {
       if (existing.status === InviteStatus.PENDING) {
         Alert.alert('Already invited', 'You have already invited this user to this round.');
@@ -81,7 +81,7 @@ export default function RoundSetupScreen() {
       } else {
         Alert.alert('Re-inviting', 'Sending a new invite to this user.');
         // Update declined invite back to PENDING
-        await createInvite(db, {
+        await smcCreateInvite(db, {
           id: existing.id,
           round_id: roundId,
           inviter_id: user.id,
@@ -94,7 +94,7 @@ export default function RoundSetupScreen() {
 
     // Create invite
     try {
-      await createInvite(db, {
+      await smcCreateInvite(db, {
         id: Crypto.randomUUID(),
         round_id: roundId,
         inviter_id: user.id,
@@ -121,7 +121,7 @@ export default function RoundSetupScreen() {
       Alert.alert('Squad full', `Maximum ${MAX_SQUAD_SIZE} shooters per squad.`);
       return;
     }
-    await addShooterEntry(db, {
+    await smcAddShooterEntry(db, {
       id: Crypto.randomUUID(),
       squad_id: squadId,
       round_id: roundId!,
@@ -138,7 +138,7 @@ export default function RoundSetupScreen() {
       Alert.alert('Cannot remove', 'At least one shooter is required.');
       return;
     }
-    await removeShooterEntry(db, entryId);
+    await smcRemoveShooterEntry(db, entryId);
     await reload();
   }
 

--- a/app/round/[id]/summary.tsx
+++ b/app/round/[id]/summary.tsx
@@ -8,11 +8,11 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { usePowerSync } from '@powersync/react';
-import { getRound } from '@/db/queries/rounds';
-import { getSquadByRound, listShooterEntries } from '@/db/queries/squads';
-import { listStands } from '@/db/queries/stands';
-import { getShooterRoundScore, getResultsForStandAndShooter } from '@/db/queries/scoring';
-import { getClubPositions } from '@/db/queries/clubs';
+import { smcGetRound } from '@/db/queries/smc-rounds';
+import { smcGetSquadByRound, smcListShooterEntries } from '@/db/queries/smc-squads';
+import { smcListStands } from '@/db/queries/smc-stands';
+import { smcGetShooterRoundScore, smcGetResultsForStandAndShooter } from '@/db/queries/smc-scoring';
+import { smcGetClubPositions } from '@/db/queries/smc-clubs';
 import { useAuth } from '@/providers/AuthProvider';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors, Spacing, FontSize, BorderRadius, PRESENTATION_LABELS } from '@/lib/constants';
@@ -51,18 +51,18 @@ export default function RoundSummaryScreen() {
     (async () => {
       if (!roundId) return;
 
-      const r = await getRound(db, roundId);
+      const r = await smcGetRound(db, roundId);
       setRound(r);
 
-      const stands = await listStands(db, roundId);
-      const squad = await getSquadByRound(db, roundId);
+      const stands = await smcListStands(db, roundId);
+      const squad = await smcGetSquadByRound(db, roundId);
       if (!squad) { setIsLoading(false); return; }
-      const shooters = await listShooterEntries(db, squad.id);
+      const shooters = await smcListShooterEntries(db, squad.id);
 
       // Per-shooter totals
       const scores: ShooterScore[] = [];
       for (const shooter of shooters) {
-        const score = await getShooterRoundScore(db, roundId, shooter.id);
+        const score = await smcGetShooterRoundScore(db, roundId, shooter.id);
         scores.push({ shooter, kills: score.kills, total: score.total, hasConflicts: score.hasConflicts });
       }
       setShooterScores(scores);
@@ -72,7 +72,7 @@ export default function RoundSummaryScreen() {
       for (const stand of stands) {
         const results: StandBreakdown['results'] = [];
         for (const shooter of shooters) {
-          const standResults = await getResultsForStandAndShooter(db, stand.id, shooter.id);
+          const standResults = await smcGetResultsForStandAndShooter(db, stand.id, shooter.id);
           const kills = standResults.filter((r) => r.result === ShotResult.KILL).length;
           results.push({ shooter, kills, total: standResults.length });
         }
@@ -80,7 +80,7 @@ export default function RoundSummaryScreen() {
       }
 
       if (r?.club_id) {
-        const positions = await getClubPositions(db, r.club_id);
+        const positions = await smcGetClubPositions(db, r.club_id);
         const grouped = new Map<string, StandBreakdown[]>();
 
         for (const bd of breakdowns) {

--- a/components/UserSearch.tsx
+++ b/components/UserSearch.tsx
@@ -11,7 +11,7 @@ import {
 import { usePowerSync } from '@powersync/react';
 import { Colors } from '@/lib/constants';
 import type { User } from '@/lib/types';
-import { searchUsersByDisplayName, searchUsersByUserId } from '@/db/queries/users';
+import { smcSearchUsersByDisplayName, smcSearchUsersByUserId } from '@/db/queries/smc-users';
 
 interface UserSearchProps {
   onSelectUser: (user: User) => void;
@@ -51,13 +51,13 @@ export function UserSearch({ onSelectUser, excludeUserId, currentUserInternalId 
       // If query starts with @, search for partial user_id match
       if (query.startsWith('@')) {
         const userIdHandle = query.slice(1);
-        foundUsers = await searchUsersByUserId(db, userIdHandle);
+        foundUsers = await smcSearchUsersByUserId(db, userIdHandle);
         if (foundUsers.length === 0) {
           setMessage(`No user found matching @${userIdHandle}`);
         }
       } else {
         // Search by display name (only discoverable users)
-        foundUsers = await searchUsersByDisplayName(db, query);
+        foundUsers = await smcSearchUsersByDisplayName(db, query);
         if (foundUsers.length === 0) {
           setMessage('No users found. Try searching by exact User ID (e.g., @username).');
         }

--- a/db/queries/smc-clubs.ts
+++ b/db/queries/smc-clubs.ts
@@ -1,7 +1,7 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
 import type { Club, ClubPosition, ClubStand } from '@/lib/types';
 
-export async function listClubs(
+export async function smcListClubs(
   db: AbstractPowerSyncDatabase,
   search?: string,
 ): Promise<Club[]> {
@@ -15,14 +15,14 @@ export async function listClubs(
   return db.getAll<Club>('SELECT * FROM clubs ORDER BY name');
 }
 
-export async function getClub(
+export async function smcGetClub(
   db: AbstractPowerSyncDatabase,
   id: string,
 ): Promise<Club | null> {
   return db.getOptional<Club>('SELECT * FROM clubs WHERE id = ?', [id]);
 }
 
-export async function getClubPositions(
+export async function smcGetClubPositions(
   db: AbstractPowerSyncDatabase,
   clubId: string,
 ): Promise<ClubPosition[]> {
@@ -32,7 +32,7 @@ export async function getClubPositions(
   );
 }
 
-export async function getClubStandsByPosition(
+export async function smcGetClubStandsByPosition(
   db: AbstractPowerSyncDatabase,
   positionId: string,
 ): Promise<ClubStand[]> {
@@ -42,20 +42,20 @@ export async function getClubStandsByPosition(
   );
 }
 
-export async function getClubWithDetails(
+export async function smcGetClubWithDetails(
   db: AbstractPowerSyncDatabase,
   clubId: string,
 ): Promise<{
   club: Club;
   positions: (ClubPosition & { stands: ClubStand[] })[];
 } | null> {
-  const club = await getClub(db, clubId);
+  const club = await smcGetClub(db, clubId);
   if (!club) return null;
 
-  const positions = await getClubPositions(db, clubId);
+  const positions = await smcGetClubPositions(db, clubId);
   const positionsWithStands = await Promise.all(
     positions.map(async (pos) => {
-      const stands = await getClubStandsByPosition(db, pos.id);
+      const stands = await smcGetClubStandsByPosition(db, pos.id);
       return { ...pos, stands };
     }),
   );

--- a/db/queries/smc-invites.ts
+++ b/db/queries/smc-invites.ts
@@ -5,7 +5,7 @@ import { InviteStatus } from '@/lib/types';
 /**
  * Create a new invite
  */
-export async function createInvite(
+export async function smcCreateInvite(
   db: AbstractPowerSyncDatabase,
   params: {
     id: string;
@@ -25,7 +25,7 @@ export async function createInvite(
 /**
  * Get invite by ID
  */
-export async function getInviteById(
+export async function smcGetInviteById(
   db: AbstractPowerSyncDatabase,
   inviteId: string,
 ): Promise<Invite | null> {
@@ -35,7 +35,7 @@ export async function getInviteById(
 /**
  * List all invites for a specific round
  */
-export async function listInvitesForRound(
+export async function smcListInvitesForRound(
   db: AbstractPowerSyncDatabase,
   roundId: string,
 ): Promise<Invite[]> {
@@ -49,7 +49,7 @@ export async function listInvitesForRound(
  * List incoming invites for a user (where they are the invitee)
  * Optionally filter by status
  */
-export async function listIncomingInvitesForUser(
+export async function smcListIncomingInvitesForUser(
   db: AbstractPowerSyncDatabase,
   inviteeUserId: string,
   status?: string,
@@ -69,7 +69,7 @@ export async function listIncomingInvitesForUser(
 /**
  * List outgoing invites for a round by a specific user
  */
-export async function listOutgoingInvitesForRound(
+export async function smcListOutgoingInvitesForRound(
   db: AbstractPowerSyncDatabase,
   roundId: string,
   inviterId: string,
@@ -81,9 +81,9 @@ export async function listOutgoingInvitesForRound(
 }
 
 /**
- * Update invite status (PENDING → ACCEPTED or DECLINED)
+ * Update invite status (PENDING -> ACCEPTED or DECLINED)
  */
-export async function updateInviteStatus(
+export async function smcUpdateInviteStatus(
   db: AbstractPowerSyncDatabase,
   inviteId: string,
   status: string,
@@ -95,7 +95,7 @@ export async function updateInviteStatus(
  * Check if an invite already exists between these users for this round
  * Returns the existing invite if found, null otherwise
  */
-export async function checkDuplicateInvite(
+export async function smcCheckDuplicateInvite(
   db: AbstractPowerSyncDatabase,
   roundId: string,
   inviteeUserId: string,
@@ -109,7 +109,7 @@ export async function checkDuplicateInvite(
 /**
  * Get pending invite count for a user
  */
-export async function getPendingInviteCount(
+export async function smcGetPendingInviteCount(
   db: AbstractPowerSyncDatabase,
   inviteeUserId: string,
 ): Promise<number> {

--- a/db/queries/smc-rounds.ts
+++ b/db/queries/smc-rounds.ts
@@ -1,7 +1,7 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
 import { RoundStatus, type Round } from '@/lib/types';
 
-export async function createRound(
+export async function smcCreateRound(
   db: AbstractPowerSyncDatabase,
   params: {
     id: string;
@@ -19,11 +19,11 @@ export async function createRound(
   );
 }
 
-export async function getRound(db: AbstractPowerSyncDatabase, id: string): Promise<Round | null> {
+export async function smcGetRound(db: AbstractPowerSyncDatabase, id: string): Promise<Round | null> {
   return db.getOptional<Round>('SELECT * FROM rounds WHERE id = ?', [id]);
 }
 
-export async function listRounds(db: AbstractPowerSyncDatabase, userId: string): Promise<Round[]> {
+export async function smcListRounds(db: AbstractPowerSyncDatabase, userId: string): Promise<Round[]> {
   return db.getAll<Round>(
     `SELECT DISTINCT r.* FROM rounds r
      LEFT JOIN shooter_entries se ON se.round_id = r.id
@@ -33,7 +33,7 @@ export async function listRounds(db: AbstractPowerSyncDatabase, userId: string):
   );
 }
 
-export async function updateRoundStatus(
+export async function smcUpdateRoundStatus(
   db: AbstractPowerSyncDatabase,
   id: string,
   status: RoundStatus,
@@ -42,7 +42,7 @@ export async function updateRoundStatus(
   await db.execute('UPDATE rounds SET status = ?, updated_at = ? WHERE id = ?', [status, now, id]);
 }
 
-export async function updateRoundNotes(
+export async function smcUpdateRoundNotes(
   db: AbstractPowerSyncDatabase,
   id: string,
   notes: string,

--- a/db/queries/smc-scoring.ts
+++ b/db/queries/smc-scoring.ts
@@ -1,7 +1,7 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
 import type { TargetResultRecord, ShotResult } from '@/lib/types';
 
-export async function recordTargetResult(
+export async function smcRecordTargetResult(
   db: AbstractPowerSyncDatabase,
   params: {
     id: string;
@@ -22,7 +22,7 @@ export async function recordTargetResult(
   );
 }
 
-export async function getResultsForStandAndShooter(
+export async function smcGetResultsForStandAndShooter(
   db: AbstractPowerSyncDatabase,
   standId: string,
   shooterEntryId: string,
@@ -46,7 +46,7 @@ export async function getResultsForStandAndShooter(
   return deduped;
 }
 
-export async function getResultsForStand(
+export async function smcGetResultsForStand(
   db: AbstractPowerSyncDatabase,
   standId: string,
 ): Promise<TargetResultRecord[]> {
@@ -56,7 +56,7 @@ export async function getResultsForStand(
   );
 }
 
-export async function getResultsForRound(
+export async function smcGetResultsForRound(
   db: AbstractPowerSyncDatabase,
   roundId: string,
 ): Promise<TargetResultRecord[]> {
@@ -69,7 +69,7 @@ export async function getResultsForRound(
   );
 }
 
-export async function updateTargetResult(
+export async function smcUpdateTargetResult(
   db: AbstractPowerSyncDatabase,
   id: string,
   result: ShotResult,
@@ -77,7 +77,7 @@ export async function updateTargetResult(
   await db.execute('UPDATE target_results SET result = ? WHERE id = ?', [result, id]);
 }
 
-export async function getShooterRoundScore(
+export async function smcGetShooterRoundScore(
   db: AbstractPowerSyncDatabase,
   roundId: string,
   shooterEntryId: string,
@@ -119,7 +119,7 @@ export interface ConflictedShotGroup {
   records: TargetResultRecord[];
 }
 
-export async function getRoundConflicts(
+export async function smcGetRoundConflicts(
   db: AbstractPowerSyncDatabase,
   roundId: string,
 ): Promise<ConflictedShotGroup[]> {
@@ -139,7 +139,7 @@ export async function getRoundConflicts(
     return [];
   }
 
-  const allResults = await getResultsForRound(db, roundId);
+  const allResults = await smcGetResultsForRound(db, roundId);
 
   return dupes.map((dupe) => ({
     ...dupe,
@@ -154,7 +154,7 @@ export async function getRoundConflicts(
   }));
 }
 
-export async function resolveConflict(
+export async function smcResolveConflict(
   db: AbstractPowerSyncDatabase,
   keepId: string,
   deleteIds: string[],

--- a/db/queries/smc-squads.ts
+++ b/db/queries/smc-squads.ts
@@ -1,21 +1,21 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
 import type { Squad, ShooterEntry, EnrichedShooterEntry } from '@/lib/types';
 
-export async function createSquad(
+export async function smcCreateSquad(
   db: AbstractPowerSyncDatabase,
   params: { id: string; round_id: string },
 ): Promise<void> {
   await db.execute('INSERT INTO squads (id, round_id) VALUES (?, ?)', [params.id, params.round_id]);
 }
 
-export async function getSquadByRound(
+export async function smcGetSquadByRound(
   db: AbstractPowerSyncDatabase,
   roundId: string,
 ): Promise<Squad | null> {
   return db.getOptional<Squad>('SELECT * FROM squads WHERE round_id = ?', [roundId]);
 }
 
-export async function addShooterEntry(
+export async function smcAddShooterEntry(
   db: AbstractPowerSyncDatabase,
   params: {
     id: string;
@@ -32,7 +32,7 @@ export async function addShooterEntry(
   );
 }
 
-export async function listShooterEntries(
+export async function smcListShooterEntries(
   db: AbstractPowerSyncDatabase,
   squadId: string,
 ): Promise<ShooterEntry[]> {
@@ -42,14 +42,14 @@ export async function listShooterEntries(
   );
 }
 
-export async function removeShooterEntry(
+export async function smcRemoveShooterEntry(
   db: AbstractPowerSyncDatabase,
   id: string,
 ): Promise<void> {
   await db.execute('DELETE FROM shooter_entries WHERE id = ?', [id]);
 }
 
-export async function listShooterEntriesWithUsers(
+export async function smcListShooterEntriesWithUsers(
   db: AbstractPowerSyncDatabase,
   squadId: string,
 ): Promise<EnrichedShooterEntry[]> {

--- a/db/queries/smc-stands.ts
+++ b/db/queries/smc-stands.ts
@@ -1,7 +1,7 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
 import type { Stand, PresentationType, TargetConfig } from '@/lib/types';
 
-export async function createStand(
+export async function smcCreateStand(
   db: AbstractPowerSyncDatabase,
   params: {
     id: string;
@@ -21,21 +21,21 @@ export async function createStand(
   );
 }
 
-export async function listStands(
+export async function smcListStands(
   db: AbstractPowerSyncDatabase,
   roundId: string,
 ): Promise<Stand[]> {
   return db.getAll<Stand>('SELECT * FROM stands WHERE round_id = ? ORDER BY stand_number', [roundId]);
 }
 
-export async function getStand(
+export async function smcGetStand(
   db: AbstractPowerSyncDatabase,
   id: string,
 ): Promise<Stand | null> {
   return db.getOptional<Stand>('SELECT * FROM stands WHERE id = ?', [id]);
 }
 
-export async function updateStand(
+export async function smcUpdateStand(
   db: AbstractPowerSyncDatabase,
   id: string,
   params: Partial<Pick<Stand, 'target_config' | 'presentation' | 'presentation_notes' | 'num_targets'>>,
@@ -50,4 +50,3 @@ export async function updateStand(
   values.push(id);
   await db.execute(`UPDATE stands SET ${sets.join(', ')} WHERE id = ?`, values);
 }
-

--- a/db/queries/smc-users.ts
+++ b/db/queries/smc-users.ts
@@ -4,7 +4,7 @@ import type { User } from '@/lib/types';
 /**
  * Get user by their internal ID (UUID from auth)
  */
-export async function getUserById(
+export async function smcGetUserById(
   db: AbstractPowerSyncDatabase,
   userId: string,
 ): Promise<User | null> {
@@ -14,7 +14,7 @@ export async function getUserById(
 /**
  * Get user by their unique user_id handle (e.g., "@phil_marr")
  */
-export async function getUserByUserId(
+export async function smcGetUserByUserId(
   db: AbstractPowerSyncDatabase,
   userIdHandle: string,
 ): Promise<User | null> {
@@ -27,7 +27,7 @@ export async function getUserByUserId(
 /**
  * Search users by display name (only returns discoverable users)
  */
-export async function searchUsersByDisplayName(
+export async function smcSearchUsersByDisplayName(
   db: AbstractPowerSyncDatabase,
   displayName: string,
 ): Promise<User[]> {
@@ -42,7 +42,7 @@ export async function searchUsersByDisplayName(
  * Search users by partial user_id match (works regardless of discoverable setting)
  * This allows users to be found by their handle even if they're not discoverable
  */
-export async function searchUsersByUserId(
+export async function smcSearchUsersByUserId(
   db: AbstractPowerSyncDatabase,
   userIdHandle: string,
 ): Promise<User[]> {
@@ -56,7 +56,7 @@ export async function searchUsersByUserId(
 /**
  * Check if a user_id handle is available (not taken)
  */
-export async function isUserIdAvailable(
+export async function smcIsUserIdAvailable(
   db: AbstractPowerSyncDatabase,
   userIdHandle: string,
 ): Promise<boolean> {
@@ -70,7 +70,7 @@ export async function isUserIdAvailable(
 /**
  * Update user profile fields
  */
-export async function updateUserProfile(
+export async function smcUpdateUserProfile(
   db: AbstractPowerSyncDatabase,
   userId: string,
   updates: {


### PR DESCRIPTION
## Summary
- Renamed all 7 query files in `db/queries/` with `smc-` prefix (e.g., `clubs.ts` → `smc-clubs.ts`)
- Prefixed all ~40 exported functions with `smc` (e.g., `getRound` → `smcGetRound`)
- Updated all import paths and call sites across ~20 caller files (screens, components, providers, tests)

## Test plan
- [x] TypeScript compiles with zero errors (`tsc --noEmit`)
- [x] All 34 tests pass across 7 test suites
- [x] No stale references to old un-prefixed import paths
- [x] Only `smc-*.ts` files remain in `db/queries/`

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)