### PR TITLE
Limit recent rounds on home screen to 3 most recent

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -24,7 +24,7 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       if (!user) return;
-      smcListRounds(db, user.id).then((all) => setRecent(all.slice(0, 5)));
+      smcListRounds(db, user.id).then((all) => setRecent(all.slice(0, 3)));
       if (user.user_id) {
         smcListIncomingInvitesForUser(db, user.user_id, InviteStatus.PENDING)
           .then((invites) => setPendingInviteCount(invites.length));


### PR DESCRIPTION
## Summary
Reduces the number of recent rounds displayed on the home screen from 5 to 3.

## Changes
- Updated `app/(tabs)/index.tsx` to slice rounds to 3 instead of 5

## Testing
- TypeScript type checking: passed
- Full test suite (34 tests): passed
- Manual verification: confirmed

Closes #56