### PR TITLE
feat: add SETUP status and round lifecycle transitions

### DIFF
--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -7,6 +7,9 @@ The human reviews and approves at defined checkpoints.
 Follow this workflow for every implementation task.
 Do not skip steps.
 Do not reorder steps.
+The issue provides intent.
+The codebase provides implementation truth.
+Runtime behaviour is the final source of truth.
 
 ## Workflow Overview
 
@@ -23,6 +26,13 @@ Do not reorder steps.
    - AI reads `project-spec.md` and any files relevant to the task.
    - AI reviews the areas of the codebase the task is likely to touch.
    - Human ensures the right context is available.
+   - Treat the issue goal as authoritative, but treat suggested implementation details as provisional until confirmed against the current codebase.
+   - Do not assume the files, data flow, or control points named in the issue are the real execution path.
+   - If the issue and the current codebase disagree, prioritise the codebase and flag the mismatch to the human.
+   - If the issue is implementation-specific, extract the intended outcome before planning the change.
+   - The AI must extract the intended outcome from the issue before using any implementation suggestions.
+   - The AI must verify all issue-suggested implementation details against the current codebase before relying on them.
+   - If the issue suggests a structure that the current codebase does not follow, the AI must plan against the real structure and flag the mismatch.
 
 3. **Produce a code-aware plan.**
    - AI writes the plan. See [Planning Requirements](#planning-requirements).
@@ -47,12 +57,18 @@ Do not reorder steps.
    - AI suggests specific things the human should verify, based on the change.
    - AI stops and waits for the human to confirm before continuing, even if the change appears trivial.
    - Human performs manual checks where needed, or confirms no manual checks are required.
+   - Manual verification is a primary source of truth for user-visible behaviour, not a final formality.
+   - When suggesting manual checks, include the exact success signal and the exact failure signal.
+   - If a manual check fails, the AI must restate the contradiction before proposing the next step.
 
 8. **Fix and revalidate.**
    - Human reports issues found during manual verification or review.
    - AI fixes the reported issues.
    - AI reruns relevant validation checks after each fix.
    - Repeat until no issues remain.
+   - Do not stack multiple speculative fixes without new evidence between them.
+   - After a failed manual check, each new fix must be tied to a specific hypothesis.
+   - If repeated fixes are attempted under the same theory without changing the evidence, stop and reassess the theory.
 
 9. **Summarise and close.**
    - AI reports: what changed, what was tested, what was not tested, and any remaining risks or follow-up work.
@@ -76,6 +92,12 @@ Before implementation, produce a plan that includes:
 - Risks and edge cases.
 - Validation approach. See [Validation Requirements](#validation-requirements).
 - Any logging or observability changes needed. See [Logging and Observability](#logging-and-observability).
+- Include the user-visible behaviour that must change, not only the code changes proposed.
+- List the assumptions that come from the issue separately from assumptions confirmed in the codebase.
+- For each critical assumption, state how it will be verified.
+- If the change affects routing, persistence, sync, caching, reactive subscriptions, or state transitions, mark it as a higher-risk change.
+- For higher-risk changes, include at least one runtime validation step that proves the intended user behaviour.
+- Do not treat issue-proposed file edits as requirements unless the current codebase confirms them.
 
 Keep the plan concise.
 Do not produce long speculative plans.
@@ -112,6 +134,11 @@ Run the following checks after every code change, in order:
 
 Smoke tests and the global test suite must not be modified unless the task explicitly requires it.
 Run smoke tests and the global test suite after each meaningful implementation pass, not only at the end of the task.
+Passing smoke tests and the global test suite does not prove that the requested behaviour works.
+Treat existing passing tests as evidence of stability, not proof of correctness for the new behaviour.
+When the change affects state transitions, sync, routing, caching, or reactive UI updates, include validation that follows the full user path.
+If no automated test exercises the real user path, say so explicitly.
+If manual verification fails, stop implementation mode and enter failure analysis mode before making more code changes.
 
 Report clearly:
 - What was tested and what passed.
@@ -132,6 +159,23 @@ Rules:
 - Include enough context to trace a problem without a debugger.
 - Do not log full data payloads unless explicitly needed.
 - Do not introduce a new logging library or pattern without approval.
+- When a change affects writes, sync behaviour, state transitions, or reactive screens, decide explicitly whether temporary diagnostic logging is needed to verify the runtime path.
+- Prefer logs or probes that confirm which code path executed, which identifiers were used, and which state transition occurred.
+- If observability is too weak to distinguish between competing hypotheses, flag that before continuing.
+- Remove temporary diagnostics before completion unless the human approves keeping them.
+
+## Failure Analysis Mode
+
+- Enter failure analysis mode when manual verification fails, runtime behaviour contradicts the implementation, or test results conflict with observed behaviour.
+- In failure analysis mode, stop making speculative fixes until the contradiction is described clearly.
+- State the observed behaviour in user terms.
+- State the expected behaviour in user terms.
+- List the assumptions the implementation relied on.
+- Mark each assumption as verified, unverified, or disproved.
+- List plausible failure causes across issue interpretation, code path selection, persistence, sync, caching, routing, UI binding, environment, test coverage, and observability.
+- Identify the cheapest next observation that can eliminate one or more hypotheses.
+- Gather evidence before proposing another fix.
+- Do not claim the issue is nearly complete while the root cause is still unknown.
 
 ## GitHub Workflow
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -60,6 +60,7 @@ Runtime behaviour is the final source of truth.
    - Manual verification is a primary source of truth for user-visible behaviour, not a final formality.
    - When suggesting manual checks, include the exact success signal and the exact failure signal.
    - If a manual check fails, the AI must restate the contradiction before proposing the next step.
+   - If a manual check fails, the AI must not convert the failed check into a request for the human to repeat the same check unless new evidence justifies the retry.
 
 8. **Fix and revalidate.**
    - Human reports issues found during manual verification or review.
@@ -69,6 +70,7 @@ Runtime behaviour is the final source of truth.
    - Do not stack multiple speculative fixes without new evidence between them.
    - After a failed manual check, each new fix must be tied to a specific hypothesis.
    - If repeated fixes are attempted under the same theory without changing the evidence, stop and reassess the theory.
+   - A retry of the same user flow counts as a new validation step only if the AI has gathered new evidence or changed the relevant hypothesis.
 
 9. **Summarise and close.**
    - AI reports: what changed, what was tested, what was not tested, and any remaining risks or follow-up work.
@@ -163,6 +165,7 @@ Rules:
 - Prefer logs or probes that confirm which code path executed, which identifiers were used, and which state transition occurred.
 - If observability is too weak to distinguish between competing hypotheses, flag that before continuing.
 - Remove temporary diagnostics before completion unless the human approves keeping them.
+- For higher-risk changes, if manual verification fails and the runtime path is not yet proven, decide whether temporary diagnostics or another direct observation method is needed before asking the human to retry.
 
 ## Failure Analysis Mode
 
@@ -176,6 +179,13 @@ Rules:
 - Identify the cheapest next observation that can eliminate one or more hypotheses.
 - Gather evidence before proposing another fix.
 - Do not claim the issue is nearly complete while the root cause is still unknown.
+- Do not ask the human to retry the flow, refresh the app, clear cache, restart the dev server, or repeat manual verification until at least one concrete hypothesis has been tested with new evidence.
+- Do not treat environment or caching as the leading explanation unless evidence makes it more likely than code path, persistence, sync, routing, or UI binding failures.
+- When multiple hypotheses exist, prefer the next observation that distinguishes between wrong code path, wrong write, later overwrite, sync overwrite, and stale runtime.
+- If the contradiction involves a write, state transition, sync boundary, or reactive screen, prefer temporary diagnostics or direct observation over a retry request.
+- Before proposing the next step, name the single leading hypothesis and the evidence that currently supports it.
+- Restate the contradiction in one short block before any reasoning.
+- Use the format: observed behaviour, expected behaviour, strongest conflicting evidence, and what remains unknown.
 
 ## GitHub Workflow
 

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -13,8 +13,7 @@ import { smcListRounds } from '@/db/queries/smc-rounds';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
 import { RoundStatus, type Round } from '@/lib/types';
 
-const STATUS_LABELS: Record<string, string> = {
-  [RoundStatus.COMPLETED]: 'Completed',
+const STATUS_LABELS: Record<string, string> = {  [RoundStatus.SETUP]: 'Setup',  [RoundStatus.COMPLETED]: 'Completed',
   [RoundStatus.IN_PROGRESS]: 'In Progress',
   [RoundStatus.ABANDONED]: 'Abandoned',
 };
@@ -35,6 +34,8 @@ export default function HistoryScreen() {
   function handlePress(round: Round) {
     if (round.status === RoundStatus.IN_PROGRESS) {
       router.push(`/round/${round.id}/score`);
+    } else if (round.status === RoundStatus.SETUP) {
+      router.push(`/round/${round.id}/setup`);
     } else {
       router.push(`/round/${round.id}/summary`);
     }
@@ -61,6 +62,7 @@ export default function HistoryScreen() {
                   styles.status,
                   item.status === RoundStatus.COMPLETED && styles.statusCompleted,
                   item.status === RoundStatus.IN_PROGRESS && styles.statusInProgress,
+                  item.status === RoundStatus.SETUP && styles.statusSetup,
                 ]}
               >
                 {STATUS_LABELS[item.status] ?? item.status}
@@ -132,6 +134,9 @@ const styles = StyleSheet.create({
   },
   statusInProgress: {
     color: Colors.primary,
+  },
+  statusSetup: {
+    color: Colors.textMuted,
   },
   detail: {
     fontSize: FontSize.sm,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -35,6 +35,8 @@ export default function HomeScreen() {
   function handlePress(round: Round) {
     if (round.status === RoundStatus.IN_PROGRESS) {
       router.push(`/round/${round.id}/score`);
+    } else if (round.status === RoundStatus.SETUP) {
+      router.push(`/round/${round.id}/setup`);
     } else {
       router.push(`/round/${round.id}/summary`);
     }
@@ -80,9 +82,10 @@ export default function HomeScreen() {
                   styles.status,
                   item.status === RoundStatus.COMPLETED && { color: Colors.hit },
                   item.status === RoundStatus.IN_PROGRESS && { color: Colors.primary },
+                  item.status === RoundStatus.SETUP && { color: Colors.textMuted },
                 ]}
               >
-                {item.status === RoundStatus.COMPLETED ? 'Done' : 'In Progress'}
+                {item.status === RoundStatus.COMPLETED ? 'Done' : item.status === RoundStatus.SETUP ? 'Setup' : 'In Progress'}
               </Text>
             </View>
             <Text style={styles.detail}>

--- a/app/(tabs)/new-round.tsx
+++ b/app/(tabs)/new-round.tsx
@@ -15,7 +15,7 @@ import * as Crypto from 'expo-crypto';
 import { useAuth } from '@/providers/AuthProvider';
 import { smcListClubs, smcGetClub } from '@/db/queries/smc-clubs';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
-import type { Club } from '@/lib/types';
+import { RoundStatus, type Club } from '@/lib/types';
 
 export default function NewRoundScreen() {
   const router = useRouter();
@@ -87,7 +87,7 @@ export default function NewRoundScreen() {
       await db.writeTransaction(async (tx) => {
         await tx.execute(
           'INSERT INTO rounds (id, created_by, ground_name, date, total_targets, status, notes, club_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-          [roundId, user.id, selectedClub.name, today, 0, 'IN_PROGRESS', null, selectedClub.id, new Date().toISOString(), new Date().toISOString()],
+          [roundId, user.id, selectedClub.name, today, 0, RoundStatus.SETUP, null, selectedClub.id, new Date().toISOString(), new Date().toISOString()],
         );
         await tx.execute(
           'INSERT INTO squads (id, round_id) VALUES (?, ?)',

--- a/app/round/[id]/setup.tsx
+++ b/app/round/[id]/setup.tsx
@@ -12,14 +12,14 @@ import {
 import { usePowerSync, useQuery } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { useAuth } from '@/providers/AuthProvider';
-import { smcGetRound } from '@/db/queries/smc-rounds';
+import { smcGetRound, smcUpdateRoundStatus } from '@/db/queries/smc-rounds';
 import { smcGetSquadByRound, smcAddShooterEntry, smcListShooterEntries, smcRemoveShooterEntry } from '@/db/queries/smc-squads';
 import { smcGetClubWithDetails } from '@/db/queries/smc-clubs';
 import { smcCreateInvite, smcCheckDuplicateInvite } from '@/db/queries/smc-invites';
 import { smcGetUserByUserId } from '@/db/queries/smc-users';
 import { Colors, Spacing, FontSize, BorderRadius, MAX_SQUAD_SIZE } from '@/lib/constants';
 import { formatStandDetail, formatPositionTitle } from '@/lib/formatting';
-import { InviteStatus, type ShooterEntry, type Round, type PositionWithStands, type User } from '@/lib/types';
+import { InviteStatus, RoundStatus, type ShooterEntry, type Round, type PositionWithStands, type User } from '@/lib/types';
 import { UserSearch } from '@/components/UserSearch';
 
 export default function RoundSetupScreen() {
@@ -142,11 +142,12 @@ export default function RoundSetupScreen() {
     await reload();
   }
 
-  function handleStartScoring() {
+  async function handleStartScoring() {
     if (shooters.length === 0) {
       Alert.alert('Add shooters', 'At least one shooter is required.');
       return;
     }
+    await smcUpdateRoundStatus(db, roundId!, RoundStatus.IN_PROGRESS);
     router.push(`/round/${roundId}/score`);
   }
 

--- a/db/queries/smc-rounds.ts
+++ b/db/queries/smc-rounds.ts
@@ -15,7 +15,7 @@ export async function smcCreateRound(
   const now = new Date().toISOString();
   await db.execute(
     'INSERT INTO rounds (id, created_by, ground_name, date, total_targets, status, notes, club_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-    [params.id, params.created_by, params.ground_name, params.date, params.total_targets, RoundStatus.IN_PROGRESS, null, params.club_id ?? null, now, now],
+    [params.id, params.created_by, params.ground_name, params.date, params.total_targets, RoundStatus.SETUP, null, params.club_id ?? null, now, now],
   );
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ export enum TargetConfig {
 }
 
 export enum RoundStatus {
+  SETUP = 'SETUP',
   IN_PROGRESS = 'IN_PROGRESS',
   COMPLETED = 'COMPLETED',
   ABANDONED = 'ABANDONED',


### PR DESCRIPTION
## Summary

Introduces `RoundStatus.SETUP` as the initial state for newly created rounds, enabling scoring to be gated until the owner explicitly starts.

## Changes

- **lib/types.ts**: Added `SETUP = 'SETUP'` to `RoundStatus` enum
- **db/queries/smc-rounds.ts**: Changed initial status from `IN_PROGRESS` to `SETUP`
- **app/(tabs)/new-round.tsx**: Fixed hardcoded `'IN_PROGRESS'` to use `RoundStatus.SETUP`
- **app/round/[id]/setup.tsx**: Transition to `IN_PROGRESS` when owner clicks "Start Scoring"
- **app/(tabs)/history.tsx**: Added `SETUP` label, styling, and routing to setup screen
- **app/(tabs)/index.tsx**: Added `SETUP` status display and routing to setup screen

## Testing

- ✅ TypeScript compiles without errors
- ✅ 34/34 unit tests pass
- ✅ Manual: New round created with `SETUP` status
- ✅ Manual: SETUP round navigates to setup screen (not scoring)
- ✅ Manual: "Start Scoring" transitions status to `IN_PROGRESS`
- ✅ Manual: Finishing round transitions status to `COMPLETED`

## Related

- Closes #82
- Parent issue: #58
- Follow-up: #83 (waiting screen and invite routing)