### PR TITLE
Fix #88: show conflicted status for unresolved rounds

### DIFF
--- a/__tests__/db/queries/rounds.test.ts
+++ b/__tests__/db/queries/rounds.test.ts
@@ -1,0 +1,68 @@
+import { createMockDb } from '../../helpers/mockDb';
+import { describe, it, expect, jest } from '@jest/globals';
+import { smcCreateRound, smcListRounds, smcUpdateRoundStatus } from '@/db/queries/smc-rounds';
+import { RoundStatus, type RoundListItem } from '@/lib/types';
+
+describe('smcCreateRound', () => {
+  it('creates rounds in SETUP status', async () => {
+    const db = createMockDb();
+
+    await smcCreateRound(db, {
+      id: 'round1',
+      created_by: 'user1',
+      ground_name: 'Club Alpha',
+      date: '2026-03-28',
+      total_targets: 100,
+      club_id: null,
+    });
+
+    expect(db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO rounds'),
+      expect.arrayContaining(['round1', 'user1', 'Club Alpha', '2026-03-28', 100, RoundStatus.SETUP]),
+    );
+  });
+});
+
+describe('smcListRounds', () => {
+  it('requests conflict-aware rounds for owner or participant', async () => {
+    const db = createMockDb();
+    const rows: RoundListItem[] = [
+      {
+        id: 'round1',
+        created_by: 'user1',
+        ground_name: 'Club Alpha',
+        date: '2026-03-28',
+        total_targets: 100,
+        status: RoundStatus.COMPLETED,
+        notes: null,
+        club_id: null,
+        created_at: '2026-03-28T10:00:00Z',
+        updated_at: '2026-03-28T10:00:00Z',
+        has_unresolved_conflicts: 1,
+      },
+    ];
+    (db.getAll as any).mockResolvedValue(rows);
+
+    const result = await smcListRounds(db, 'user1');
+
+    expect(result).toEqual(rows);
+
+    const [sql, params] = (db.getAll as any).mock.calls[0];
+    expect(sql).toContain('has_unresolved_conflicts');
+    expect(sql).toContain('HAVING COUNT(*) > 1');
+    expect(params).toEqual(['user1', 'user1']);
+  });
+});
+
+describe('smcUpdateRoundStatus', () => {
+  it('updates round status with timestamp', async () => {
+    const db = createMockDb();
+
+    await smcUpdateRoundStatus(db, 'round1', RoundStatus.IN_PROGRESS);
+
+    expect(db.execute).toHaveBeenCalledWith(
+      'UPDATE rounds SET status = ?, updated_at = ? WHERE id = ?',
+      [RoundStatus.IN_PROGRESS, expect.any(String), 'round1'],
+    );
+  });
+});

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -11,7 +11,7 @@ import { usePowerSync } from '@powersync/react';
 import { useAuth } from '@/providers/AuthProvider';
 import { smcListRounds } from '@/db/queries/smc-rounds';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
-import { RoundStatus, type Round } from '@/lib/types';
+import { RoundStatus, type RoundListItem } from '@/lib/types';
 
 const STATUS_LABELS: Record<string, string> = {  [RoundStatus.SETUP]: 'Setup',  [RoundStatus.COMPLETED]: 'Completed',
   [RoundStatus.IN_PROGRESS]: 'In Progress',
@@ -22,7 +22,7 @@ export default function HistoryScreen() {
   const db = usePowerSync();
   const { user } = useAuth();
   const router = useRouter();
-  const [rounds, setRounds] = useState<Round[]>([]);
+  const [rounds, setRounds] = useState<RoundListItem[]>([]);
 
   useFocusEffect(
     useCallback(() => {
@@ -31,7 +31,7 @@ export default function HistoryScreen() {
     }, [db, user]),
   );
 
-  function handlePress(round: Round) {
+  function handlePress(round: RoundListItem) {
     if (round.status === RoundStatus.IN_PROGRESS) {
       router.push(`/round/${round.id}/score`);
     } else if (round.status === RoundStatus.SETUP) {
@@ -62,12 +62,13 @@ export default function HistoryScreen() {
               <Text
                 style={[
                   styles.status,
-                  item.status === RoundStatus.COMPLETED && styles.statusCompleted,
-                  item.status === RoundStatus.IN_PROGRESS && styles.statusInProgress,
-                  item.status === RoundStatus.SETUP && styles.statusSetup,
+                  item.has_unresolved_conflicts === 1 && styles.statusConflicted,
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.COMPLETED && styles.statusCompleted,
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.IN_PROGRESS && styles.statusInProgress,
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.SETUP && styles.statusSetup,
                 ]}
               >
-                {STATUS_LABELS[item.status] ?? item.status}
+                {item.has_unresolved_conflicts === 1 ? 'Conflicted' : (STATUS_LABELS[item.status] ?? item.status)}
               </Text>
             </View>
             <Text style={styles.detail}>
@@ -130,6 +131,9 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: Colors.textMuted,
     textTransform: 'uppercase',
+  },
+  statusConflicted: {
+    color: Colors.miss,
   },
   statusCompleted: {
     color: Colors.hit,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,13 +12,13 @@ import { useAuth } from '@/providers/AuthProvider';
 import { smcListRounds } from '@/db/queries/smc-rounds';
 import { smcListIncomingInvitesForUser } from '@/db/queries/smc-invites';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
-import { RoundStatus, InviteStatus, type Round } from '@/lib/types';
+import { RoundStatus, InviteStatus, type RoundListItem } from '@/lib/types';
 
 export default function HomeScreen() {
   const db = usePowerSync();
   const { user } = useAuth();
   const router = useRouter();
-  const [recent, setRecent] = useState<Round[]>([]);
+  const [recent, setRecent] = useState<RoundListItem[]>([]);
   const [pendingInviteCount, setPendingInviteCount] = useState(0);
 
   useFocusEffect(
@@ -32,7 +32,7 @@ export default function HomeScreen() {
     }, [db, user]),
   );
 
-  function handlePress(round: Round) {
+  function handlePress(round: RoundListItem) {
     if (round.status === RoundStatus.IN_PROGRESS) {
       router.push(`/round/${round.id}/score`);
     } else if (round.status === RoundStatus.SETUP) {
@@ -82,12 +82,19 @@ export default function HomeScreen() {
               <Text
                 style={[
                   styles.status,
-                  item.status === RoundStatus.COMPLETED && { color: Colors.hit },
-                  item.status === RoundStatus.IN_PROGRESS && { color: Colors.primary },
-                  item.status === RoundStatus.SETUP && { color: Colors.textMuted },
+                  item.has_unresolved_conflicts === 1 && { color: Colors.miss },
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.COMPLETED && { color: Colors.hit },
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.IN_PROGRESS && { color: Colors.primary },
+                  item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.SETUP && { color: Colors.textMuted },
                 ]}
               >
-                {item.status === RoundStatus.COMPLETED ? 'Done' : item.status === RoundStatus.SETUP ? 'Setup' : 'In Progress'}
+                {item.has_unresolved_conflicts === 1
+                  ? 'Conflicted'
+                  : item.status === RoundStatus.COMPLETED
+                    ? 'Done'
+                    : item.status === RoundStatus.SETUP
+                      ? 'Setup'
+                      : 'In Progress'}
               </Text>
             </View>
             <Text style={styles.detail}>

--- a/db/queries/smc-rounds.ts
+++ b/db/queries/smc-rounds.ts
@@ -1,5 +1,5 @@
 import type { AbstractPowerSyncDatabase } from '@powersync/common';
-import { RoundStatus, type Round } from '@/lib/types';
+import { RoundStatus, type Round, type RoundListItem } from '@/lib/types';
 
 export async function smcCreateRound(
   db: AbstractPowerSyncDatabase,
@@ -23,9 +23,21 @@ export async function smcGetRound(db: AbstractPowerSyncDatabase, id: string): Pr
   return db.getOptional<Round>('SELECT * FROM rounds WHERE id = ?', [id]);
 }
 
-export async function smcListRounds(db: AbstractPowerSyncDatabase, userId: string): Promise<Round[]> {
-  return db.getAll<Round>(
-    `SELECT DISTINCT r.* FROM rounds r
+export async function smcListRounds(db: AbstractPowerSyncDatabase, userId: string): Promise<RoundListItem[]> {
+  return db.getAll<RoundListItem>(
+    `SELECT DISTINCT
+       r.*,
+       CASE
+         WHEN EXISTS (
+           SELECT 1
+           FROM target_results tr
+           WHERE tr.round_id = r.id
+           GROUP BY tr.shooter_entry_id, tr.target_number, tr.bird_number
+           HAVING COUNT(*) > 1
+         ) THEN 1
+         ELSE 0
+       END AS has_unresolved_conflicts
+     FROM rounds r
      LEFT JOIN shooter_entries se ON se.round_id = r.id
      WHERE r.created_by = ? OR se.user_id = ?
      ORDER BY r.created_at DESC`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,10 @@ export interface Round {
   updated_at: string;
 }
 
+export interface RoundListItem extends Round {
+  has_unresolved_conflicts: number;
+}
+
 export interface Squad {
   id: string;
   round_id: string;


### PR DESCRIPTION
## Summary
- compute unresolved conflict state in round list query
- show `Conflicted` status on Home and History when unresolved conflicts exist
- keep routing behavior unchanged for conflicted rounds
- add rounds query tests for conflict-aware list behavior

## Validation
- Smoke: `CI=1 npx expo start --port 8090` (pass)
- Global tests: `npm test -- --runInBand` (8/8 suites, 37/37 tests)
- Targeted tests: `npm test -- __tests__/db/queries/rounds.test.ts --runInBand` (1/1 suite, 3/3 tests)
- Manual checks:
  - Home/History completed+conflicted round shows Conflicted (pass)
  - Home/History completed+non-conflicted round shows normal status (pass)
  - Tapping conflicted round routes correctly (pass)
