### PR TITLE
fix: make setup screen squad list reactive to sync changes

### DIFF
--- a/app/round/[id]/setup.tsx
+++ b/app/round/[id]/setup.tsx
@@ -13,7 +13,7 @@ import { usePowerSync, useQuery } from '@powersync/react';
 import * as Crypto from 'expo-crypto';
 import { useAuth } from '@/providers/AuthProvider';
 import { smcGetRound, smcUpdateRoundStatus } from '@/db/queries/smc-rounds';
-import { smcGetSquadByRound, smcAddShooterEntry, smcListShooterEntries, smcRemoveShooterEntry } from '@/db/queries/smc-squads';
+import { smcGetSquadByRound, smcAddShooterEntry, smcRemoveShooterEntry } from '@/db/queries/smc-squads';
 import { smcGetClubWithDetails } from '@/db/queries/smc-clubs';
 import { smcCreateInvite, smcCheckDuplicateInvite } from '@/db/queries/smc-invites';
 import { smcGetUserByUserId } from '@/db/queries/smc-users';
@@ -29,10 +29,19 @@ export default function RoundSetupScreen() {
   const { user } = useAuth();
 
   const [round, setRound] = useState<Round | null>(null);
-  const [shooters, setShooters] = useState<ShooterEntry[]>([]);
   const [squadId, setSquadId] = useState<string | null>(null);
   const [newShooterName, setNewShooterName] = useState('');
   const [clubPositions, setClubPositions] = useState<PositionWithStands[]>([]);
+
+  // Reactively watch shooter entries — auto-updates when invitees accept or owner modifies squad
+  const { data: shooterRows } = useQuery<ShooterEntry>(
+    `SELECT se.* FROM shooter_entries se
+     JOIN squads s ON se.squad_id = s.id
+     WHERE s.round_id = ?
+     ORDER BY se.position_in_squad`,
+    [roundId ?? ''],
+  );
+  const shooters = shooterRows ?? [];
 
   // Reactively watch pending invites — auto-updates when sync changes the invites table
   const { data: pendingInviteRows } = useQuery<{ id: string; invitee_user_id: string; status: string }>(
@@ -57,8 +66,6 @@ export default function RoundSetupScreen() {
     const squad = await smcGetSquadByRound(db, roundId);
     if (squad) {
       setSquadId(squad.id);
-      const entries = await smcListShooterEntries(db, squad.id);
-      setShooters(entries);
     }
   }, [db, roundId]);
 


### PR DESCRIPTION
## Summary

Fixes the owner's setup screen not reactively showing squad changes when invitees accept invites via PowerSync sync.

## Problem

The setup screen loaded shooter entries imperatively using `useState` + `useFocusEffect`. When an invitee accepted an invite on another device and their shooter entry synced in via PowerSync, the owner's setup screen didn't update — only a navigation away and back would refresh the list.

## Fix

Replaced imperative shooter loading with a `useQuery` reactive subscription in `app/round/[id]/setup.tsx` — the same pattern already used by the waiting screen and the pending invites section.

## Verification

- Build: passes (web export)
- Tests: 34/34 passing across 7 suites
- Manual: owner sees new squad member appear reactively when invitee accepts — confirmed
- All 10 acceptance criteria from #58 verified

## Follow-up

Identified that round screens don't enforce role/status access on direct URL navigation — tracked in #94.

Closes #58