### PR TITLE
Fix inconsistent round status labels between Home and History

### DIFF
--- a/__tests__/lib/formatting.test.ts
+++ b/__tests__/lib/formatting.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+import { formatRoundStatusLabel } from '@/lib/formatting';
+import { RoundStatus } from '@/lib/types';
+
+describe('formatRoundStatusLabel', () => {
+  it('formats known round statuses consistently', () => {
+    expect(formatRoundStatusLabel(RoundStatus.SETUP)).toBe('Setup');
+    expect(formatRoundStatusLabel(RoundStatus.IN_PROGRESS)).toBe('In Progress');
+    expect(formatRoundStatusLabel(RoundStatus.COMPLETED)).toBe('Completed');
+    expect(formatRoundStatusLabel(RoundStatus.ABANDONED)).toBe('Abandoned');
+  });
+
+  it('returns unknown statuses unchanged', () => {
+    expect(formatRoundStatusLabel('CUSTOM')).toBe('CUSTOM');
+  });
+});

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -11,12 +11,8 @@ import { usePowerSync } from '@powersync/react';
 import { useAuth } from '@/providers/AuthProvider';
 import { smcListRounds } from '@/db/queries/smc-rounds';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
+import { formatRoundStatusLabel } from '@/lib/formatting';
 import { RoundStatus, type RoundListItem } from '@/lib/types';
-
-const STATUS_LABELS: Record<string, string> = {  [RoundStatus.SETUP]: 'Setup',  [RoundStatus.COMPLETED]: 'Completed',
-  [RoundStatus.IN_PROGRESS]: 'In Progress',
-  [RoundStatus.ABANDONED]: 'Abandoned',
-};
 
 export default function HistoryScreen() {
   const db = usePowerSync();
@@ -68,7 +64,7 @@ export default function HistoryScreen() {
                   item.has_unresolved_conflicts !== 1 && item.status === RoundStatus.SETUP && styles.statusSetup,
                 ]}
               >
-                {item.has_unresolved_conflicts === 1 ? 'Conflicted' : (STATUS_LABELS[item.status] ?? item.status)}
+                {item.has_unresolved_conflicts === 1 ? 'Conflicted' : formatRoundStatusLabel(item.status)}
               </Text>
             </View>
             <Text style={styles.detail}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/providers/AuthProvider';
 import { smcListRounds } from '@/db/queries/smc-rounds';
 import { smcListIncomingInvitesForUser } from '@/db/queries/smc-invites';
 import { Colors, Spacing, FontSize, BorderRadius } from '@/lib/constants';
+import { formatRoundStatusLabel } from '@/lib/formatting';
 import { RoundStatus, InviteStatus, type RoundListItem } from '@/lib/types';
 
 export default function HomeScreen() {
@@ -90,11 +91,7 @@ export default function HomeScreen() {
               >
                 {item.has_unresolved_conflicts === 1
                   ? 'Conflicted'
-                  : item.status === RoundStatus.COMPLETED
-                    ? 'Done'
-                    : item.status === RoundStatus.SETUP
-                      ? 'Setup'
-                      : 'In Progress'}
+                  : formatRoundStatusLabel(item.status)}
               </Text>
             </View>
             <Text style={styles.detail}>

--- a/lib/formatting.ts
+++ b/lib/formatting.ts
@@ -1,7 +1,18 @@
 import { PRESENTATION_LABELS, TARGET_CONFIG_LABELS } from './constants';
-import type { ClubPosition, ClubStand, PresentationType, Stand, TargetConfig } from './types';
+import { RoundStatus, type ClubPosition, type ClubStand, type PresentationType, type Stand, type TargetConfig } from './types';
 
 type StandLike = Pick<Stand | ClubStand, 'stand_number' | 'target_config' | 'presentation' | 'num_targets'>;
+
+const ROUND_STATUS_LABELS: Record<RoundStatus, string> = {
+  [RoundStatus.SETUP]: 'Setup',
+  [RoundStatus.IN_PROGRESS]: 'In Progress',
+  [RoundStatus.COMPLETED]: 'Completed',
+  [RoundStatus.ABANDONED]: 'Abandoned',
+};
+
+export function formatRoundStatusLabel(status: RoundStatus | string): string {
+  return ROUND_STATUS_LABELS[status as RoundStatus] ?? status;
+}
 
 export function formatStandDetail(stand: StandLike): string {
   const config = TARGET_CONFIG_LABELS[stand.target_config as TargetConfig] ?? stand.target_config;


### PR DESCRIPTION
## Summary
- centralize round status label formatting in a shared formatter
- update the Home and History tabs to use the same completed status label
- add unit coverage for round status label formatting

## Validation
- app loads successfully
- `npm test -- --runInBand`
- `npm test -- --runInBand --runTestsByPath __tests__/lib/formatting.test.ts`
- manual verification: completed rounds show `Completed` on both Home and History

Refs #84