### PR TITLE
Remove Clubs tab from bottom navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -26,12 +26,6 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="clubs"
-        options={{
-          title: 'Clubs',
-        }}
-      />
-      <Tabs.Screen
         name="history"
         options={{
           title: 'History',
@@ -41,6 +35,12 @@ export default function TabLayout() {
         name="profile"
         options={{
           title: 'Profile',
+        }}
+      />
+      <Tabs.Screen
+        name="clubs"
+        options={{
+          href: null,
         }}
       />
     </Tabs>


### PR DESCRIPTION
## Summary
- remove the visible `Clubs` entry from the bottom tab navigator
- keep the `clubs` route registered with `href: null` so it no longer appears in the tab bar
- preserve existing club-related screens outside the bottom navigation scope

## Why
The Clubs tab is outside the current MVP navigation flow and adds unnecessary clutter to the primary tab bar.

## Validation
- `npx expo export --platform web`
- `npm test -- --runInBand`
- manual verification: confirmed the app no longer shows `Clubs` in the bottom navigation