### PR TITLE
fix: allow squad members to write stands via RLS (#59)

### DIFF
--- a/supabase/migrations/011_allow_squad_stand_writes.sql
+++ b/supabase/migrations/011_allow_squad_stand_writes.sql
@@ -1,0 +1,16 @@
+-- =============================================================
+-- Migration 011: Allow Squad Stand Writes
+-- Permits any squad member to write to stands.
+-- Replaces the SELECT-only policy for shooters with an ALL policy.
+--
+-- Fixes: #59 — RLS policy violation when syncing stands table
+--
+-- Follows the same pattern as migration 008 (target_results).
+-- =============================================================
+
+DROP POLICY IF EXISTS stands_select_as_shooter ON public.stands;
+
+CREATE POLICY stands_all_as_shooter ON public.stands
+  FOR ALL USING (
+    round_id IN (SELECT public.get_user_round_ids(auth.uid()::text))
+  );


### PR DESCRIPTION
## Summary

Fixes #59 — RLS policy violation when syncing stands table.

## Changes

Adds migration `011_allow_squad_stand_writes.sql`:

- Drops the SELECT-only `stands_select_as_shooter` policy
- Creates `stands_all_as_shooter FOR ALL` using `get_user_round_ids()`, granting squad members full CRUD on stands in rounds they participate in

Follows the same pattern as migration 008 (`target_results`).

## Root Cause

The `stands_owner FOR ALL` policy only permitted the round owner to write stands. When a squad member's device created a stand locally (deterministic ID, INSERT OR IGNORE), the PowerSync upload upsert was rejected by RLS.

## Testing

- Full test suite: 39/39 pass, no regressions
- Supabase policy state verified via SQL query
- Manual in-app verification confirmed — stand creation as squad member syncs without error

## Notes

- Migration already applied to Supabase
- No client code changes required