### PR TITLE
fix: enforce role and status access guards on round screens (#94)

### DIFF
--- a/__tests__/lib/round-guards.test.ts
+++ b/__tests__/lib/round-guards.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from '@jest/globals';
+import { getSetupGuardRedirect, getScoreGuardRedirect } from '@/lib/round-guards';
+import { RoundStatus, type Round } from '@/lib/types';
+
+function makeRound(overrides: Partial<Round> = {}): Round {
+  return {
+    id: 'r1',
+    created_by: 'owner-1',
+    ground_name: 'Test Ground',
+    date: '2026-04-14',
+    total_targets: 100,
+    status: RoundStatus.SETUP,
+    notes: null,
+    club_id: null,
+    created_at: '2026-04-14T00:00:00Z',
+    updated_at: '2026-04-14T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('getSetupGuardRedirect', () => {
+  it('returns home when round is null', () => {
+    expect(getSetupGuardRedirect(null, 'user-1', 'r1')).toBe('/');
+  });
+
+  it('allows access for the round owner', () => {
+    const round = makeRound({ created_by: 'owner-1' });
+    expect(getSetupGuardRedirect(round, 'owner-1', 'r1')).toBeNull();
+  });
+
+  it('redirects non-owner to waiting when round is in SETUP', () => {
+    const round = makeRound({ status: RoundStatus.SETUP });
+    expect(getSetupGuardRedirect(round, 'other-user', 'r1')).toBe('/round/r1/waiting');
+  });
+
+  it('redirects non-owner to score when round is IN_PROGRESS', () => {
+    const round = makeRound({ status: RoundStatus.IN_PROGRESS });
+    expect(getSetupGuardRedirect(round, 'other-user', 'r1')).toBe('/round/r1/score');
+  });
+
+  it('redirects non-owner to summary when round is COMPLETED', () => {
+    const round = makeRound({ status: RoundStatus.COMPLETED });
+    expect(getSetupGuardRedirect(round, 'other-user', 'r1')).toBe('/round/r1/summary');
+  });
+
+  it('redirects non-owner to summary when round is ABANDONED', () => {
+    const round = makeRound({ status: RoundStatus.ABANDONED });
+    expect(getSetupGuardRedirect(round, 'other-user', 'r1')).toBe('/round/r1/summary');
+  });
+});
+
+describe('getScoreGuardRedirect', () => {
+  it('returns home when round is null', () => {
+    expect(getScoreGuardRedirect(null, 'user-1', 'r1')).toBe('/');
+  });
+
+  it('allows access when round is IN_PROGRESS', () => {
+    const round = makeRound({ status: RoundStatus.IN_PROGRESS });
+    expect(getScoreGuardRedirect(round, 'owner-1', 'r1')).toBeNull();
+  });
+
+  it('redirects owner to setup when round is in SETUP', () => {
+    const round = makeRound({ status: RoundStatus.SETUP, created_by: 'owner-1' });
+    expect(getScoreGuardRedirect(round, 'owner-1', 'r1')).toBe('/round/r1/setup');
+  });
+
+  it('redirects non-owner to waiting when round is in SETUP', () => {
+    const round = makeRound({ status: RoundStatus.SETUP, created_by: 'owner-1' });
+    expect(getScoreGuardRedirect(round, 'other-user', 'r1')).toBe('/round/r1/waiting');
+  });
+
+  it('redirects to summary when round is COMPLETED', () => {
+    const round = makeRound({ status: RoundStatus.COMPLETED });
+    expect(getScoreGuardRedirect(round, 'owner-1', 'r1')).toBe('/round/r1/summary');
+  });
+
+  it('redirects to summary when round is ABANDONED', () => {
+    const round = makeRound({ status: RoundStatus.ABANDONED });
+    expect(getScoreGuardRedirect(round, 'owner-1', 'r1')).toBe('/round/r1/summary');
+  });
+});

--- a/app/round/[id]/score.tsx
+++ b/app/round/[id]/score.tsx
@@ -37,6 +37,7 @@ import {
   type ClubStand,
   type PositionWithStands,
 } from '@/lib/types';
+import { getScoreGuardRedirect } from '@/lib/round-guards';
 
 // Graceful haptics: no-op if not available (web)
 let triggerHaptic = () => {};
@@ -90,8 +91,16 @@ export default function ScoringScreen() {
   // Initial data load
   useEffect(() => {
     (async () => {
-      if (!roundId) return;
+      if (!roundId || !user) return;
       const r = await smcGetRound(db, roundId);
+
+      // Access guard: scoring screen requires IN_PROGRESS status
+      const redirect = getScoreGuardRedirect(r, user.id, roundId);
+      if (redirect) {
+        router.replace(redirect);
+        return;
+      }
+
       setRound(r);
 
       const squad = await smcGetSquadByRound(db, roundId);
@@ -124,7 +133,7 @@ export default function ScoringScreen() {
 
       setIsLoading(false);
     })();
-  }, [db, roundId]);
+  }, [db, roundId, user, router]);
 
   // Reactively watch shooter entries — picks up new squad members via sync
   useEffect(() => {

--- a/app/round/[id]/setup.tsx
+++ b/app/round/[id]/setup.tsx
@@ -20,6 +20,7 @@ import { smcGetUserByUserId } from '@/db/queries/smc-users';
 import { Colors, Spacing, FontSize, BorderRadius, MAX_SQUAD_SIZE } from '@/lib/constants';
 import { formatStandDetail, formatPositionTitle } from '@/lib/formatting';
 import { InviteStatus, RoundStatus, type ShooterEntry, type Round, type PositionWithStands, type User } from '@/lib/types';
+import { getSetupGuardRedirect } from '@/lib/round-guards';
 import { UserSearch } from '@/components/UserSearch';
 
 export default function RoundSetupScreen() {
@@ -51,8 +52,16 @@ export default function RoundSetupScreen() {
   const pendingInvites = pendingInviteRows ?? [];
 
   const reload = useCallback(async () => {
-    if (!roundId) return;
+    if (!roundId || !user) return;
     const r = await smcGetRound(db, roundId);
+
+    // Access guard: only the round owner can use the setup screen
+    const redirect = getSetupGuardRedirect(r, user.id, roundId);
+    if (redirect) {
+      router.replace(redirect);
+      return;
+    }
+
     setRound(r);
 
     // Load club positions
@@ -67,7 +76,7 @@ export default function RoundSetupScreen() {
     if (squad) {
       setSquadId(squad.id);
     }
-  }, [db, roundId]);
+  }, [db, roundId, user, router]);
 
   useFocusEffect(
     useCallback(() => {

--- a/lib/round-guards.ts
+++ b/lib/round-guards.ts
@@ -1,0 +1,47 @@
+import { RoundStatus, type Round } from '@/lib/types';
+
+/**
+ * Returns a redirect path if the current user should not access the setup screen,
+ * or null if access is allowed (user is the round owner).
+ */
+export function getSetupGuardRedirect(
+  round: Round | null,
+  userId: string,
+  roundId: string,
+): string | null {
+  if (!round) return '/';
+
+  if (round.created_by !== userId) {
+    if (round.status === RoundStatus.IN_PROGRESS) {
+      return `/round/${roundId}/score`;
+    }
+    if (round.status === RoundStatus.COMPLETED || round.status === RoundStatus.ABANDONED) {
+      return `/round/${roundId}/summary`;
+    }
+    return `/round/${roundId}/waiting`;
+  }
+
+  return null;
+}
+
+/**
+ * Returns a redirect path if the round is not in the correct status for the scoring screen,
+ * or null if access is allowed (round is IN_PROGRESS).
+ */
+export function getScoreGuardRedirect(
+  round: Round | null,
+  userId: string,
+  roundId: string,
+): string | null {
+  if (!round) return '/';
+
+  if (round.status !== RoundStatus.IN_PROGRESS) {
+    if (round.status === RoundStatus.SETUP) {
+      const isOwner = round.created_by === userId;
+      return isOwner ? `/round/${roundId}/setup` : `/round/${roundId}/waiting`;
+    }
+    return `/round/${roundId}/summary`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #94. Round screens are now guarded against direct URL / deep-link access by non-owners or when the round is in the wrong status.

## Changes

- **`lib/round-guards.ts`** — new module with two pure functions:
  - `getSetupGuardRedirect()` — returns a redirect path if the user is not the round owner
  - `getScoreGuardRedirect()` — returns a redirect path if the round is not IN_PROGRESS
- **`app/round/[id]/setup.tsx`** — calls `getSetupGuardRedirect()` after loading the round; non-owners are redirected to waiting/score/summary based on round status
- **`app/round/[id]/score.tsx`** — calls `getScoreGuardRedirect()` after loading the round; redirects to setup/waiting (if SETUP) or summary (if COMPLETED/ABANDONED)
- **`__tests__/lib/round-guards.test.ts`** — 12 unit tests covering all guard branches

## Redirect logic

| Screen | Condition | Redirect |
|--------|-----------|----------|
| Setup | Round not found | `/` |
| Setup | Non-owner, SETUP | `/round/:id/waiting` |
| Setup | Non-owner, IN_PROGRESS | `/round/:id/score` |
| Setup | Non-owner, COMPLETED/ABANDONED | `/round/:id/summary` |
| Score | Round not found | `/` |
| Score | SETUP, owner | `/round/:id/setup` |
| Score | SETUP, non-owner | `/round/:id/waiting` |
| Score | COMPLETED/ABANDONED | `/round/:id/summary` |

## Testing

- 12 new unit tests — all passing
- Full suite: 51/51 tests passing
- Build: passes
- Manual web verification was blocked by a pre-existing WASM initialization issue (PowerSync WebAssembly fails on fresh page loads in dev)