### PR TITLE
docs: sync with current codebase

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,14 +99,14 @@ components/       Reusable UI components
   LoadingPlaceholder  Centered spinner with optional message
 db/               Database layer
   schema.ts       PowerSync schema definition (10 tables)
-  queries/        Typed SQL query functions
-    rounds.ts       Round CRUD
-    squads.ts       Squad and shooter entry management
-    stands.ts       Stand CRUD
-    scoring.ts      Target results, conflict detection
-    clubs.ts        Club, position, and stand lookups
-    invites.ts      Invite CRUD and duplicate checks
-    users.ts        User search by handle
+  queries/        Typed SQL query functions (all files prefixed smc-, all exports prefixed smc)
+    smc-rounds.ts    Round CRUD
+    smc-squads.ts    Squad and shooter entry management
+    smc-stands.ts    Stand CRUD
+    smc-scoring.ts   Target results, conflict detection
+    smc-clubs.ts     Club, position, and stand lookups
+    smc-invites.ts   Invite CRUD and duplicate checks
+    smc-users.ts     User search by handle
   openDatabase.*  Platform-specific database initialisation
 lib/              Utilities, constants, and types
   types.ts        Domain enums and entity interfaces
@@ -115,6 +115,7 @@ lib/              Utilities, constants, and types
   uuid.ts         Deterministic UUID generation from SHA-256 hashes
   supabase.ts     Supabase client configuration
   powersync-connector.ts  PowerSync ↔ Supabase sync connector
+  round-guards.ts  Role/status access guards for round setup and scoring screens
 providers/        React context providers
   DatabaseProvider.tsx  ← PowerSync init
   AuthProvider.tsx      ← Supabase auth state + user record sync

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,7 @@ The `supabase/migrations/` directory contains migration files that define the fu
 | `007_allow_invitee_shooter_entry.sql` | Allow invited users to be added as shooters |
 | `008_allow_squad_scoring.sql` | Allow squad members to record scores |
 | `010_unique_club_stand_per_round.sql` | Unique index preventing duplicate stands per club stand per round |
+| `011_allow_squad_stand_writes.sql` | RLS policy allowing squad members to write stand records |
 
 If setting up a fresh Supabase project, apply these migrations in order. PowerSync sync rules are defined in `supabase/powersync-sync-rules.yaml`.
 

--- a/docs/offline-first.md
+++ b/docs/offline-first.md
@@ -91,8 +91,8 @@ These files are gitignored (they're build artifacts derived from `node_modules`)
 
 When multiple devices record scores for the same round simultaneously, duplicate `(shooter_entry_id, target_number, bird_number)` combinations may sync to the same device. The app handles conflicts in four stages:
 
-1. **Deduplication during active scoring**: `getResultsForStandAndShooter` orders rows by `created_at` and keeps only the first record for each target and bird, so the scorer can continue without the state machine skipping ahead.
-2. **Conflict-aware totals**: `getShooterRoundScore` flags shooters with duplicates and suppresses their rolled-up totals until the duplicates are resolved.
+1. **Deduplication during active scoring**: `smcGetResultsForStandAndShooter` orders rows by `created_at` and keeps only the first record for each target and bird, so the scorer can continue without the state machine skipping ahead.
+2. **Conflict-aware totals**: `smcGetShooterRoundScore` flags shooters with duplicates and suppresses their rolled-up totals until the duplicates are resolved.
 3. **UI warnings**: The scoring screen shows a "Sync Issue" warning for the active shooter, and the summary screen marks conflicted shooters explicitly.
 4. **Organizer resolution**: The round creator can open the conflict-resolution screen (`/round/[id]/conflicts`), choose the winning record for each duplicated shot, and delete the losing rows from `target_results`.
 

--- a/docs/query-api-reference.md
+++ b/docs/query-api-reference.md
@@ -4,13 +4,15 @@ The query layer lives in `db/queries/`. Every function takes an `AbstractPowerSy
 
 All functions are async. All reads return data from the local SQLite database (never from the network). All writes go to local SQLite and are queued for sync via the PowerSync CRUD upload queue.
 
+All exported functions are prefixed with `smc` and live in files prefixed with `smc-` (e.g. `db/queries/smc-clubs.ts`).
+
 ---
 
-## clubs.ts
+## smc-clubs.ts
 
 Functions for reading club reference data (clubs, positions, stands). This data is read-only — it's seeded via Supabase migrations and synced down to devices.
 
-### `listClubs(db, search?): Promise<Club[]>`
+### `smcListClubs(db, search?): Promise<Club[]>`
 
 Returns all clubs ordered by name. If `search` is provided, filters by `name LIKE %search%`.
 
@@ -19,21 +21,21 @@ Returns all clubs ordered by name. If `search` is provided, filters by `name LIK
 | `db` | `AbstractPowerSyncDatabase` | Yes | Database instance |
 | `search` | `string` | No | Filter clubs by name (case-insensitive LIKE) |
 
-### `getClub(db, id): Promise<Club | null>`
+### `smcGetClub(db, id): Promise<Club | null>`
 
 Returns a single club by ID, or null if not found.
 
-### `getClubPositions(db, clubId): Promise<ClubPosition[]>`
+### `smcGetClubPositions(db, clubId): Promise<ClubPosition[]>`
 
 Returns all positions for a club, ordered by `position_number`.
 
-### `getClubStandsByPosition(db, positionId): Promise<ClubStand[]>`
+### `smcGetClubStandsByPosition(db, positionId): Promise<ClubStand[]>`
 
 Returns all stands within a position, ordered by `stand_number`.
 
-### `getClubWithDetails(db, clubId): Promise<{ club, positions } | null>`
+### `smcGetClubWithDetails(db, clubId): Promise<{ club, positions } | null>`
 
-Returns a club with all its positions and stands nested. Convenience function that calls `getClub`, `getClubPositions`, and `getClubStandsByPosition` in sequence.
+Returns a club with all its positions and stands nested. Convenience function that calls `smcGetClub`, `smcGetClubPositions`, and `smcGetClubStandsByPosition` in sequence.
 
 **Return shape:**
 ```ts
@@ -45,13 +47,13 @@ Returns a club with all its positions and stands nested. Convenience function th
 
 ---
 
-## rounds.ts
+## smc-rounds.ts
 
 Functions for creating and managing rounds.
 
-### `createRound(db, params): Promise<void>`
+### `smcCreateRound(db, params): Promise<void>`
 
-Creates a new round with status `IN_PROGRESS`. Sets `created_at` and `updated_at` to the current timestamp.
+Creates a new round with status `SETUP`. Sets `created_at` and `updated_at` to the current timestamp.
 
 | Param | Type | Required | Description |
 |:------|:-----|:---------|:------------|
@@ -62,33 +64,33 @@ Creates a new round with status `IN_PROGRESS`. Sets `created_at` and `updated_at
 | `params.total_targets` | `number` | Yes | Total target count (25, 50, 75, or 100) |
 | `params.club_id` | `string \| null` | No | Club ID if this is a club round |
 
-### `getRound(db, id): Promise<Round | null>`
+### `smcGetRound(db, id): Promise<Round | null>`
 
 Returns a single round by ID, or null if not found.
 
-### `listRounds(db, userId): Promise<Round[]>`
+### `smcListRounds(db, userId): Promise<RoundListItem[]>`
 
-Returns all rounds where the user is either the creator or a shooter in the squad. Ordered by `created_at DESC` (newest first). Uses a `LEFT JOIN` on `shooter_entries` and `DISTINCT` to avoid duplicates.
+Returns all rounds where the user is either the creator or a shooter in the squad. Ordered by `created_at DESC` (newest first). Uses a `LEFT JOIN` on `shooter_entries` and `DISTINCT` to avoid duplicates. Each row includes a computed `has_unresolved_conflicts` flag derived from duplicate target-result groups on the round.
 
-### `updateRoundStatus(db, id, status): Promise<void>`
+### `smcUpdateRoundStatus(db, id, status): Promise<void>`
 
 Updates a round's status. Sets `updated_at` to the current timestamp.
 
 | Param | Type | Description |
 |:------|:-----|:------------|
-| `status` | `RoundStatus` | `IN_PROGRESS`, `COMPLETED`, or `ABANDONED` |
+| `status` | `RoundStatus` | `SETUP`, `IN_PROGRESS`, `COMPLETED`, or `ABANDONED` |
 
-### `updateRoundNotes(db, id, notes): Promise<void>`
+### `smcUpdateRoundNotes(db, id, notes): Promise<void>`
 
 Updates a round's notes field. Sets `updated_at` to the current timestamp.
 
 ---
 
-## squads.ts
+## smc-squads.ts
 
 Functions for managing squads and shooter entries within a round.
 
-### `createSquad(db, params): Promise<void>`
+### `smcCreateSquad(db, params): Promise<void>`
 
 Creates a new squad linked to a round.
 
@@ -97,11 +99,11 @@ Creates a new squad linked to a round.
 | `params.id` | `string` | UUID for the new squad |
 | `params.round_id` | `string` | Round this squad belongs to |
 
-### `getSquadByRound(db, roundId): Promise<Squad | null>`
+### `smcGetSquadByRound(db, roundId): Promise<Squad | null>`
 
 Returns the squad for a round, or null if none exists. Each round has exactly one squad.
 
-### `addShooterEntry(db, params): Promise<void>`
+### `smcAddShooterEntry(db, params): Promise<void>`
 
 Adds a shooter to a squad.
 
@@ -114,25 +116,25 @@ Adds a shooter to a squad.
 | `params.shooter_name` | `string` | Yes | Display name for the shooter |
 | `params.position_in_squad` | `number` | Yes | Position number (1-based) |
 
-### `listShooterEntries(db, squadId): Promise<ShooterEntry[]>`
+### `smcListShooterEntries(db, squadId): Promise<ShooterEntry[]>`
 
 Returns all shooters in a squad, ordered by `position_in_squad`.
 
-### `listShooterEntriesWithUsers(db, squadId): Promise<EnrichedShooterEntry[]>`
+### `smcListShooterEntriesWithUsers(db, squadId): Promise<EnrichedShooterEntry[]>`
 
 Returns all shooters in a squad with their `user_handle` (the `@handle` from the `users` table). Uses a `LEFT JOIN` on `users`. The `user_handle` field is null for guest shooters.
 
-### `removeShooterEntry(db, id): Promise<void>`
+### `smcRemoveShooterEntry(db, id): Promise<void>`
 
 Deletes a shooter entry by ID.
 
 ---
 
-## stands.ts
+## smc-stands.ts
 
 Functions for managing stands within a round.
 
-### `createStand(db, params): Promise<void>`
+### `smcCreateStand(db, params): Promise<void>`
 
 Creates a new stand. Uses `INSERT OR IGNORE` for idempotency — if a stand with the same ID already exists (e.g. from sync), the insert is silently skipped. This is critical for club rounds where multiple devices generate the same deterministic stand ID.
 
@@ -148,15 +150,15 @@ Creates a new stand. Uses `INSERT OR IGNORE` for idempotency — if a stand with
 | `params.club_stand_id` | `string \| null` | No | Club stand reference (club rounds only) |
 | `params.club_position_id` | `string \| null` | No | Club position reference (club rounds only) |
 
-### `listStands(db, roundId): Promise<Stand[]>`
+### `smcListStands(db, roundId): Promise<Stand[]>`
 
 Returns all stands for a round, ordered by `stand_number`.
 
-### `getStand(db, id): Promise<Stand | null>`
+### `smcGetStand(db, id): Promise<Stand | null>`
 
 Returns a single stand by ID, or null if not found.
 
-### `updateStand(db, id, params): Promise<void>`
+### `smcUpdateStand(db, id, params): Promise<void>`
 
 Partially updates a stand. Only the provided fields are updated — omitted fields are unchanged.
 
@@ -169,11 +171,11 @@ Partially updates a stand. Only the provided fields are updated — omitted fiel
 
 ---
 
-## scoring.ts
+## smc-scoring.ts
 
 Functions for recording and querying shot results, calculating scores, and handling conflicts.
 
-### `recordTargetResult(db, params): Promise<void>`
+### `smcRecordTargetResult(db, params): Promise<void>`
 
 Records a single shot result. Sets `created_at` to the current timestamp. This is the most frequently called write in the app — one call per button tap during scoring.
 
@@ -189,23 +191,23 @@ Records a single shot result. Sets `created_at` to the current timestamp. This i
 | `params.recorded_by` | `string` | User ID of the person recording (may differ from shooter) |
 | `params.device_id` | `string` | Device identifier for conflict resolution |
 
-### `getResultsForStandAndShooter(db, standId, shooterEntryId): Promise<TargetResultRecord[]>`
+### `smcGetResultsForStandAndShooter(db, standId, shooterEntryId): Promise<TargetResultRecord[]>`
 
 Returns shot results for a specific shooter at a specific stand. **Deduplicates** by `(target_number, bird_number)` — if multiple records exist for the same shot (from sync conflicts), only the earliest (`created_at ASC`) is returned. This keeps the scoring state machine stable during active scoring.
 
-### `getResultsForStand(db, standId): Promise<TargetResultRecord[]>`
+### `smcGetResultsForStand(db, standId): Promise<TargetResultRecord[]>`
 
 Returns all shot results for a stand (all shooters). No deduplication — returns raw rows.
 
-### `getResultsForRound(db, roundId): Promise<TargetResultRecord[]>`
+### `smcGetResultsForRound(db, roundId): Promise<TargetResultRecord[]>`
 
 Returns all shot results for a round via a join on `stands`. Ordered by `stand_number`, `target_number`, `bird_number`. No deduplication.
 
-### `updateTargetResult(db, id, result): Promise<void>`
+### `smcUpdateTargetResult(db, id, result): Promise<void>`
 
 Updates the result of an existing target result row.
 
-### `getShooterRoundScore(db, roundId, shooterEntryId): Promise<{ kills, total, hasConflicts }>`
+### `smcGetShooterRoundScore(db, roundId, shooterEntryId): Promise<{ kills, total, hasConflicts }>`
 
 Calculates a shooter's total score for a round.
 
@@ -216,7 +218,7 @@ Calculates a shooter's total score for a round.
 { kills: number; total: number; hasConflicts: boolean }
 ```
 
-### `getRoundConflicts(db, roundId): Promise<ConflictedShotGroup[]>`
+### `smcGetRoundConflicts(db, roundId): Promise<ConflictedShotGroup[]>`
 
 Finds all conflicted shots in a round. Groups `target_results` by `(shooter_entry_id, target_number, bird_number)` and returns groups with more than one row.
 
@@ -230,17 +232,17 @@ interface ConflictedShotGroup {
 }
 ```
 
-### `resolveConflict(db, keepId, deleteIds): Promise<void>`
+### `smcResolveConflict(db, keepId, deleteIds): Promise<void>`
 
 Resolves a conflict by deleting the losing records in a write transaction. The `keepId` is accepted for API clarity but is not used in the query — only the `deleteIds` are deleted.
 
 ---
 
-## invites.ts
+## smc-invites.ts
 
 Functions for managing round invitations between users.
 
-### `createInvite(db, params): Promise<void>`
+### `smcCreateInvite(db, params): Promise<void>`
 
 Creates a new invite with status `PENDING`. Sets `created_at` to the current timestamp.
 
@@ -252,61 +254,61 @@ Creates a new invite with status `PENDING`. Sets `created_at` to the current tim
 | `params.invitee_id` | `string` | User ID (UUID) of the invitee |
 | `params.invitee_user_id` | `string` | User handle (`@handle`) of the invitee |
 
-### `getInviteById(db, inviteId): Promise<Invite | null>`
+### `smcGetInviteById(db, inviteId): Promise<Invite | null>`
 
 Returns a single invite by ID, or null if not found.
 
-### `listInvitesForRound(db, roundId): Promise<Invite[]>`
+### `smcListInvitesForRound(db, roundId): Promise<Invite[]>`
 
 Returns all invites for a round, ordered by `created_at DESC`.
 
-### `listIncomingInvitesForUser(db, inviteeUserId, status?): Promise<Invite[]>`
+### `smcListIncomingInvitesForUser(db, inviteeUserId, status?): Promise<Invite[]>`
 
 Returns invites where the user is the invitee. Matches on `invitee_user_id` (the handle, not the UUID). Optionally filters by status.
 
-### `listOutgoingInvitesForRound(db, roundId, inviterId): Promise<Invite[]>`
+### `smcListOutgoingInvitesForRound(db, roundId, inviterId): Promise<Invite[]>`
 
 Returns invites sent by a specific user for a specific round.
 
-### `updateInviteStatus(db, inviteId, status): Promise<void>`
+### `smcUpdateInviteStatus(db, inviteId, status): Promise<void>`
 
 Updates an invite's status (e.g. `PENDING` to `ACCEPTED` or `DECLINED`).
 
-### `checkDuplicateInvite(db, roundId, inviteeUserId): Promise<Invite | null>`
+### `smcCheckDuplicateInvite(db, roundId, inviteeUserId): Promise<Invite | null>`
 
 Checks if an invite already exists for this user and round. Returns the existing invite or null. Used to prevent duplicate invites.
 
-### `getPendingInviteCount(db, inviteeUserId): Promise<number>`
+### `smcGetPendingInviteCount(db, inviteeUserId): Promise<number>`
 
 Returns the count of pending invites for a user. Used for the notification badge on the home screen.
 
 ---
 
-## users.ts
+## smc-users.ts
 
 Functions for user lookup, search, and profile management.
 
-### `getUserById(db, userId): Promise<User | null>`
+### `smcGetUserById(db, userId): Promise<User | null>`
 
 Returns a user by their internal UUID (from Supabase Auth).
 
-### `getUserByUserId(db, userIdHandle): Promise<User | null>`
+### `smcGetUserByUserId(db, userIdHandle): Promise<User | null>`
 
 Returns a user by their `@handle`. Case-insensitive match using `LOWER()`.
 
-### `searchUsersByDisplayName(db, displayName): Promise<User[]>`
+### `smcSearchUsersByDisplayName(db, displayName): Promise<User[]>`
 
 Searches users by display name using `LIKE %pattern%`. **Only returns users where `discoverable = 1`** — respects the user's visibility preference.
 
-### `searchUsersByUserId(db, userIdHandle): Promise<User[]>`
+### `smcSearchUsersByUserId(db, userIdHandle): Promise<User[]>`
 
 Searches users by partial handle match using `LIKE %pattern%`. Case-insensitive. **Returns all users regardless of discoverable setting** — handles are considered public identifiers.
 
-### `isUserIdAvailable(db, userIdHandle): Promise<boolean>`
+### `smcIsUserIdAvailable(db, userIdHandle): Promise<boolean>`
 
 Returns `true` if the handle is not taken. Case-insensitive check. Used during profile setup to validate handle uniqueness.
 
-### `updateUserProfile(db, userId, updates): Promise<void>`
+### `smcUpdateUserProfile(db, userId, updates): Promise<void>`
 
 Partially updates a user's profile. Only the provided fields are updated. Sets `updated_at` to the current timestamp.
 

--- a/docs/scoring-flow.md
+++ b/docs/scoring-flow.md
@@ -131,8 +131,8 @@ Any squad member can score for any shooter. If two devices later sync overlappin
 
 The app handles conflicts in four stages:
 
-1. **Deduplication during active scoring:** `getResultsForStandAndShooter` orders rows by `created_at` and keeps only the first record for each target and bird so the scorer can continue without the state machine skipping ahead.
-2. **Conflict-aware totals:** `getShooterRoundScore` flags shooters with duplicates and suppresses their rolled-up totals until the duplicates are resolved.
+1. **Deduplication during active scoring:** `smcGetResultsForStandAndShooter` orders rows by `created_at` and keeps only the first record for each target and bird so the scorer can continue without the state machine skipping ahead.
+2. **Conflict-aware totals:** `smcGetShooterRoundScore` flags shooters with duplicates and suppresses their rolled-up totals until the duplicates are resolved.
 3. **UI warnings:** The scoring screen shows a `Sync Issue` warning for the active shooter, and the summary screen marks conflicted shooters explicitly.
 4. **Organizer resolution:** The round creator can open the conflict-resolution screen, choose the winning record for each duplicated shot, and delete the losing rows from `target_results`.
 

--- a/docs/screens-and-routing.md
+++ b/docs/screens-and-routing.md
@@ -18,6 +18,7 @@ ScoreMyClays uses Expo Router for file-based routing. The URL structure maps dir
 | `/invites` | `app/invites/index.tsx` | Accept or decline pending round invites |
 | `/profile/edit` | `app/profile/edit.tsx` | Edit display name, gear list, favourite clubs |
 | `/round/[id]/setup` | `app/round/[id]/setup.tsx` | Configure stands, squad, and invites for a round |
+| `/round/[id]/waiting` | `app/round/[id]/waiting.tsx` | Holding screen for non-owner shooters until the owner starts the round |
 | `/round/[id]/score` | `app/round/[id]/score.tsx` | Active scoring interface |
 | `/round/[id]/conflicts` | `app/round/[id]/conflicts.tsx` | Resolve duplicate shot records (round creator only) |
 | `/round/[id]/summary` | `app/round/[id]/summary.tsx` | Final scores and stand breakdown |
@@ -42,6 +43,7 @@ Stack (pushed on top of tabs)
   ├─ Invites (/invites)
   ├─ Edit Profile (/profile/edit)
   ├─ Round Setup (/round/[id]/setup)
+  ├─ Round Waiting (/round/[id]/waiting)
   ├─ Scoring (/round/[id]/score)
   ├─ Conflicts (/round/[id]/conflicts)
   └─ Summary (/round/[id]/summary)
@@ -155,6 +157,13 @@ New Round ──→ Setup ──→ Score ──→ Summary ──→ Home
 - **Squad section**: List of shooters with position numbers. Authenticated user is always Shooter 1.
 - **Invite section**: `UserSearch` component to find users by handle and send invites.
 - "Start Scoring" button — validates at least one shooter exists
+
+### Round Waiting (`app/round/[id]/waiting.tsx`)
+
+- Shown to non-owner shooters once they accept an invite or open a round that is still in setup
+- Displays round details (club, date), owner, club positions and stands, and the current squad
+- Uses a reactive query on the round's status and auto-navigates to Scoring when the owner sets the round to `IN_PROGRESS`
+- Squad list updates reactively as the owner adds or removes shooters
 
 ### Scoring (`app/round/[id]/score.tsx`)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,14 +28,17 @@ This runs Jest via the `test` script in `package.json`. All `.test.ts` files und
 ```
 __tests__/
   db/queries/       # Query function tests (one file per query module)
+    clubs.test.ts
+    invites.test.ts
+    rounds.test.ts
     scoring.test.ts
     stands.test.ts
     users.test.ts
-    invites.test.ts
-    clubs.test.ts
   lib/              # Core logic tests
-    uuid.test.ts
+    formatting.test.ts
     powersync-connector.test.ts
+    round-guards.test.ts
+    uuid.test.ts
   helpers/
     mockDb.ts       # Shared mock factory
 ```
@@ -66,14 +69,14 @@ The mock provides stubs for: `execute`, `getAll`, `getOptional`, `writeTransacti
 Test functions with **logic beyond simple CRUD** — these are the highest-value targets:
 
 - Deduplication, filtering, or transformation logic
-- Dynamic SQL builders (e.g., `updateStand`, `updateUserProfile`)
+- Dynamic SQL builders (e.g., `smcUpdateStand`, `smcUpdateUserProfile`)
 - Conflict detection and resolution
 - Search patterns and case-insensitive lookups
 - Error handling and edge cases
 
 ### What NOT to Test
 
-- Trivial single-query CRUD wrappers (e.g., `getRound`, `getStand`) — they delegate entirely to the database
+- Trivial single-query CRUD wrappers (e.g., `smcGetRound`, `smcGetStand`) — they delegate entirely to the database
 - React Native UI components or rendering
 - Framework behavior (PowerSync, Supabase, Expo)
 


### PR DESCRIPTION
Closes #108.

## Summary
- Realigns documentation with current code. Codebase is the source of truth.
- Query module filenames and exports updated to the `smc-` / `smc` prefix convention (~35 function references across `docs/query-api-reference.md`, plus scattered refs in `architecture.md`, `offline-first.md`, `scoring-flow.md`, `testing.md`).
- Adds previously undocumented entities: `/round/[id]/waiting` screen, `lib/round-guards.ts`, migration `011_allow_squad_stand_writes.sql`, and tests `rounds.test.ts`, `formatting.test.ts`, `round-guards.test.ts`.
- Corrects `smcCreateRound` status claim (`SETUP`, not `IN_PROGRESS`) and `smcListRounds` return type (`RoundListItem[]`, with `has_unresolved_conflicts` field).

## Scope
- Docs only. No code changes.
- Out of scope: README deployment wording, `reports/codebase-review.md` (dated snapshot), `ai-workflow.md` and skill prompt files, `project-spec.md` (gitignored; updated locally only).

## Test plan
- [x] `npm test` — 51/51 passing, same as baseline
- [x] Spot-check one entry in `docs/query-api-reference.md` against its source in `db/queries/smc-*.ts`
- [x] Spot-check `docs/screens-and-routing.md` waiting screen entry against `app/round/[id]/waiting.tsx`
- [x] Verify no unprefixed function names remain: `grep -rn 'listClubs\|createRound\|recordTargetResult\|getShooterRoundScore' docs/` should return nothing