### PR TITLE
fix(pwa): iOS Safari stability — OPFS VFS + SW hardening + crash telemetry

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,7 +9,10 @@ import { AuthProvider, useAuth } from '@/providers/AuthProvider';
 import { SyncProvider } from '@/providers/SyncProvider';
 import IOSInstallPrompt from '@/components/IOSInstallPrompt';
 import { registerServiceWorker } from '@/lib/registerServiceWorker';
+import { breadcrumb, installGlobalHandlers } from '@/lib/crashLog';
 
+installGlobalHandlers();
+breadcrumb('app.boot');
 registerServiceWorker();
 
 export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {

--- a/db/openDatabase.web.ts
+++ b/db/openDatabase.web.ts
@@ -1,8 +1,17 @@
 import { PowerSyncDatabase } from '@powersync/web';
 import { AppSchema } from './schema';
 
+// Pass an explicit worker URL so PowerSync uses `new Worker(urlString)` rather
+// than `new Worker(new URL('./WASQLiteDB.worker.js', import.meta.url))`.
+// The explicit URL path bypasses the Metro/Babel import.meta transform issue
+// while keeping WASM compilation on a background thread (off the main thread),
+// which prevents WebKit OOM crashes on iPhone.
+// The UMD bundle is copied to public/ by the postinstall script.
 export const db = new PowerSyncDatabase({
   schema: AppSchema,
-  database: { dbFilename: 'scoremyclays.db' },
-  flags: { useWebWorker: false },
+  database: {
+    dbFilename: 'scoremyclays.db',
+    worker: '/@powersync/worker/WASQLiteDB.umd.js',
+  },
+  flags: { useWebWorker: true },
 });

--- a/db/openDatabase.web.ts
+++ b/db/openDatabase.web.ts
@@ -1,21 +1,27 @@
-import { PowerSyncDatabase } from '@powersync/web';
+import {
+  PowerSyncDatabase,
+  WASQLiteOpenFactory,
+  WASQLiteVFS,
+} from '@powersync/web';
 import { AppSchema } from './schema';
 
-// Pass an explicit worker URL so PowerSync uses `new Worker(urlString)` rather
-// than `new Worker(new URL('./WASQLiteDB.worker.js', import.meta.url))`.
-// The explicit URL path bypasses the Metro/Babel import.meta transform issue.
+// iOS Safari's default VFS (IDBBatchAtomicVFS) overflows the call stack via
+// Asyncify under sustained writes. PowerSync's troubleshooting docs direct
+// Safari users to OPFSCoopSyncVFS, which uses OPFS sync access handles and
+// avoids the Asyncify shadow-stack growth entirely. Requires iOS 16.4+.
 //
-// cacheSizeKb is capped at 4 MB (default is 50 MB). The 50 MB default SQLite
-// page cache allocated in WASM memory, combined with the JS bundle heap,
-// exceeds iOS Safari's per-process memory limit and causes silent OOM crashes.
-// 4 MB is sufficient for this app's data volume.
-// The UMD bundle is copied to public/ by the postinstall script.
+// The worker UMD URL bypasses the Metro/Babel import.meta transform issue.
+// cacheSizeKb is bounded at 4 MB to stay well under iOS WebContent limits.
+const openFactory = new WASQLiteOpenFactory({
+  dbFilename: 'scoremyclays.db',
+  vfs: WASQLiteVFS.OPFSCoopSyncVFS,
+  worker: '/@powersync/worker/WASQLiteDB.umd.js',
+  cacheSizeKb: 4 * 1024,
+  flags: { useWebWorker: true },
+});
+
 export const db = new PowerSyncDatabase({
   schema: AppSchema,
-  database: {
-    dbFilename: 'scoremyclays.db',
-    worker: '/@powersync/worker/WASQLiteDB.umd.js',
-    cacheSizeKb: 4 * 1024,
-  },
+  database: openFactory,
   flags: { useWebWorker: true },
 });

--- a/db/openDatabase.web.ts
+++ b/db/openDatabase.web.ts
@@ -3,15 +3,19 @@ import { AppSchema } from './schema';
 
 // Pass an explicit worker URL so PowerSync uses `new Worker(urlString)` rather
 // than `new Worker(new URL('./WASQLiteDB.worker.js', import.meta.url))`.
-// The explicit URL path bypasses the Metro/Babel import.meta transform issue
-// while keeping WASM compilation on a background thread (off the main thread),
-// which prevents WebKit OOM crashes on iPhone.
+// The explicit URL path bypasses the Metro/Babel import.meta transform issue.
+//
+// cacheSizeKb is capped at 4 MB (default is 50 MB). The 50 MB default SQLite
+// page cache allocated in WASM memory, combined with the JS bundle heap,
+// exceeds iOS Safari's per-process memory limit and causes silent OOM crashes.
+// 4 MB is sufficient for this app's data volume.
 // The UMD bundle is copied to public/ by the postinstall script.
 export const db = new PowerSyncDatabase({
   schema: AppSchema,
   database: {
     dbFilename: 'scoremyclays.db',
     worker: '/@powersync/worker/WASQLiteDB.umd.js',
+    cacheSizeKb: 4 * 1024,
   },
   flags: { useWebWorker: true },
 });

--- a/docs/pwa-deployment.md
+++ b/docs/pwa-deployment.md
@@ -35,8 +35,8 @@ This deployment method is intended for developer testing and small-group early f
 - **500 MB storage cap.** iOS imposes a per-origin storage limit for web apps. Scoring data is small, so this is unlikely to be a practical issue.
 - **No native install banner on iOS.** Unlike Android, iOS Safari does not show a native install prompt. The app includes a custom in-app prompt for iOS Safari users explaining the "Add to Home Screen" flow. The prompt is dismissible and not shown again after dismissal.
 - **External links open in Safari.** When the PWA runs in standalone mode, tapping an external link bounces to Safari proper. The current auth flow is email/password, so this does not affect login. If OAuth or magic-link flows are added later, test the round trip back into the standalone PWA.
-- **First offline use requires one online load.** The service worker pre-caches the manifest, icons, and root WASM file at install time; the hashed JS bundles and the `@powersync/` worker assets are cached on first request. After one full online load the app shell is available offline.
-- **Service worker updates.** When a new version is deployed to Vercel, the service worker installs the updated version on the next launch and takes control immediately. Active scoring sessions may see a refresh; close and reopen the PWA between sessions when possible.
+- **First offline use requires one online load.** The service worker pre-caches the SPA shell (root HTML, manifest, icons) at install time; the hashed JS bundles, `@powersync/` worker assets, and WASM files are cached on first request. After one full online load the app shell is available offline.
+- **Service worker updates.** When a new version is deployed to Vercel, the updated service worker installs in the background but waits to take over. It only activates once every PWA window is fully closed and the app is relaunched. This avoids mid-session controller swaps, which iOS Safari previously surfaced as spontaneous reloads. To force a pending update to apply, fully close the PWA (swipe away from the app switcher) and reopen it from the home screen.
 
 ## How this fits alongside native deployment
 

--- a/lib/crashLog.ts
+++ b/lib/crashLog.ts
@@ -1,0 +1,105 @@
+import { Platform } from 'react-native';
+
+const STORAGE_KEY = 'smc_crash_log';
+const MAX_ENTRIES = 200;
+
+export interface Breadcrumb {
+  ts: number;
+  event: string;
+  data?: Record<string, unknown>;
+}
+
+function canUseStorage(): boolean {
+  if (Platform.OS !== 'web') return false;
+  if (typeof window === 'undefined') return false;
+  try {
+    return typeof window.localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+function read(): Breadcrumb[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(entries: Breadcrumb[]): void {
+  if (!canUseStorage()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // storage full or disabled; ignore
+  }
+}
+
+export function breadcrumb(event: string, data?: Record<string, unknown>): void {
+  const entry: Breadcrumb = { ts: Date.now(), event, data };
+  try {
+    console.log('[SMC]', event, data ?? '');
+  } catch {
+    // console unavailable; ignore
+  }
+  if (!canUseStorage()) return;
+  const entries = read();
+  entries.push(entry);
+  while (entries.length > MAX_ENTRIES) entries.shift();
+  write(entries);
+}
+
+export function getBreadcrumbs(): Breadcrumb[] {
+  return read();
+}
+
+export function clearBreadcrumbs(): void {
+  if (!canUseStorage()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function installGlobalHandlers(): void {
+  if (Platform.OS !== 'web') return;
+  if (typeof window === 'undefined') return;
+  const w = window as unknown as { _smcCrashLogInstalled?: boolean };
+  if (w._smcCrashLogInstalled) return;
+  w._smcCrashLogInstalled = true;
+
+  window.addEventListener('error', (event) => {
+    breadcrumb('window.error', {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      stack: event.error instanceof Error ? event.error.stack : undefined,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    breadcrumb('window.unhandledrejection', {
+      message: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
+
+  window.addEventListener('pageshow', (event) => {
+    breadcrumb('pageshow', { persisted: (event as PageTransitionEvent).persisted });
+  });
+
+  window.addEventListener('visibilitychange', () => {
+    breadcrumb('visibilitychange', { state: document.visibilityState });
+  });
+
+  (window as unknown as { _smcLog?: () => Breadcrumb[] })._smcLog = getBreadcrumbs;
+  (window as unknown as { _smcLogClear?: () => void })._smcLogClear = clearBreadcrumbs;
+}

--- a/lib/registerServiceWorker.ts
+++ b/lib/registerServiceWorker.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { breadcrumb } from './crashLog';
 
 export function registerServiceWorker(): void {
   if (Platform.OS !== 'web') return;
@@ -6,14 +7,17 @@ export function registerServiceWorker(): void {
   if (process.env.NODE_ENV !== 'production') return;
   if (!('serviceWorker' in window.navigator)) return;
 
-  const BUILD = 'fix/113-pwa-stability | sw: v3 | powersync: worker';
+  const BUILD = 'fix/113-pwa-stability | sw: v3 | powersync: opfs';
   (window as any)._smcBuild = BUILD;
+  breadcrumb('sw.build', { build: BUILD });
   setTimeout(() => console.log('[SMC] build:', BUILD), 3000);
 
   window.addEventListener('load', () => {
     window.navigator.serviceWorker
       .register('/sw.js')
+      .then(() => breadcrumb('sw.registered'))
       .catch((err) => {
+        breadcrumb('sw.register.error', { message: err instanceof Error ? err.message : String(err) });
         console.warn('[sw] registration failed', err);
       });
   });

--- a/lib/registerServiceWorker.ts
+++ b/lib/registerServiceWorker.ts
@@ -6,7 +6,9 @@ export function registerServiceWorker(): void {
   if (process.env.NODE_ENV !== 'production') return;
   if (!('serviceWorker' in window.navigator)) return;
 
-  console.log('[SMC] build: fix/113-pwa-stability | sw: v3 | powersync: worker');
+  const BUILD = 'fix/113-pwa-stability | sw: v3 | powersync: worker';
+  (window as any)._smcBuild = BUILD;
+  setTimeout(() => console.log('[SMC] build:', BUILD), 3000);
 
   window.addEventListener('load', () => {
     window.navigator.serviceWorker

--- a/lib/registerServiceWorker.ts
+++ b/lib/registerServiceWorker.ts
@@ -6,6 +6,8 @@ export function registerServiceWorker(): void {
   if (process.env.NODE_ENV !== 'production') return;
   if (!('serviceWorker' in window.navigator)) return;
 
+  console.log('[SMC] build: fix/113-pwa-stability | sw: v3 | powersync: worker');
+
   window.addEventListener('load', () => {
     window.navigator.serviceWorker
       .register('/sw.js')

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -4,6 +4,7 @@ import type { User } from '@/lib/types';
 import { useDatabase } from './DatabaseProvider';
 import { supabase } from '@/lib/supabase';
 import type { AuthSession } from '@supabase/supabase-js';
+import { breadcrumb } from '@/lib/crashLog';
 
 export interface AuthContextValue {
   user: User | null;
@@ -56,6 +57,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Set up auth state listener — also fires INITIAL_SESSION for the current session
     const { data: authListener } = supabase.auth.onAuthStateChange(async (event, newSession) => {
       if (!mounted) return;
+      breadcrumb('auth.state', { event, hasSession: !!newSession, uid: newSession?.user?.id });
       setSession(newSession);
 
       if (newSession?.user && event !== 'SIGNED_OUT') {

--- a/providers/DatabaseProvider.tsx
+++ b/providers/DatabaseProvider.tsx
@@ -4,6 +4,7 @@ import { PowerSyncContext } from '@powersync/react';
 import { db } from '@/db/openDatabase';
 import { SupabaseConnector } from '@/lib/powersync-connector';
 import { supabase } from '@/lib/supabase';
+import { breadcrumb } from '@/lib/crashLog';
 
 interface DatabaseContextValue {
   isReady: boolean;
@@ -27,31 +28,50 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
     // INITIAL_SESSION fires synchronously before db.init() finishes,
     // so we store the session and connect after init completes.
     const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
+      breadcrumb('db.auth', { event, hasSession: !!session });
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION') {
         if (session) {
           connector.currentSession = session;
           if (initComplete && !db.connected) {
-            db.connect(connector).catch(err => console.error('[DB] Connect error:', err));
+            breadcrumb('db.connect.start', { trigger: event });
+            db.connect(connector)
+              .then(() => breadcrumb('db.connect.done'))
+              .catch(err => {
+                breadcrumb('db.connect.error', { message: err instanceof Error ? err.message : String(err) });
+                console.error('[DB] Connect error:', err);
+              });
           }
         }
       } else if (event === 'SIGNED_OUT') {
         connector.currentSession = null;
         await db.disconnect();
+        breadcrumb('db.disconnect.done');
       }
     });
 
     (async () => {
       try {
+        breadcrumb('db.init.start');
         await db.init();
+        const resolvedVfs = (db as unknown as { options?: { database?: { waOptions?: { vfs?: string } } } })
+          .options?.database?.waOptions?.vfs;
+        breadcrumb('db.init.done', { vfs: resolvedVfs });
         initComplete = true;
         if (mounted) setIsReady(true);
 
         // Connect now if INITIAL_SESSION already provided a session
         if (connector.currentSession && !db.connected) {
-          db.connect(connector).catch(err => console.error('[DB] Connect error:', err));
+          breadcrumb('db.connect.start', { trigger: 'postInit' });
+          db.connect(connector)
+            .then(() => breadcrumb('db.connect.done'))
+            .catch(err => {
+              breadcrumb('db.connect.error', { message: err instanceof Error ? err.message : String(err) });
+              console.error('[DB] Connect error:', err);
+            });
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
+        breadcrumb('db.init.error', { message: errorMessage });
         console.error('Database initialization error:', errorMessage);
         if (mounted) setError(errorMessage);
       }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,4 +1,5 @@
 {
+  "id": "/",
   "name": "ScoreMyClays",
   "short_name": "ScoreMyClays",
   "description": "Record clay shooting round results across mobile and web.",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,14 +1,19 @@
 // ScoreMyClays service worker
 // Strategy:
-// - Precache the static asset shell on install (manifest, icons, root WASM).
-// - Stale-while-revalidate for same-origin GET requests (handles hashed JS bundles
-//   and the @powersync/ worker + WASM directory whose filenames we cannot enumerate
-//   ahead of time).
-// - Network-first for navigation requests, falling back to cached '/' so the SPA
-//   shell loads offline. The web build is `output: "single"`, so a single index.html
-//   serves every route.
+// - Precache only the minimal SPA shell on install (root HTML, manifest, icons).
+//   WASM assets populate the runtime cache on first fetch, giving the same
+//   offline behaviour after one full online load without bloating install.
+// - Stale-while-revalidate for same-origin GET requests (handles hashed JS
+//   bundles, the @powersync/ worker + WASM directory, and the root-level WASM
+//   files whose filenames we know ahead of time).
+// - Network-first for navigation requests with a strict ok-response guard,
+//   falling back to cached '/' so the SPA shell loads offline. The web build
+//   is `output: "single"`, so a single index.html serves every route.
+// - A new worker waits in the background and activates only when every PWA
+//   client has closed. No `skipWaiting()` / `clients.claim()` — mid-session
+//   controller swaps were causing spontaneous reloads on iOS Safari.
 
-const VERSION = 'v2';
+const VERSION = 'v3';
 const STATIC_CACHE = `smc-static-${VERSION}`;
 const RUNTIME_CACHE = `smc-runtime-${VERSION}`;
 
@@ -18,35 +23,29 @@ const PRECACHE_URLS = [
   '/apple-touch-icon.png',
   '/icon-192.png',
   '/icon-512.png',
-  '/wa-sqlite.wasm',
-  '/wa-sqlite-async.wasm',
-  '/mc-wa-sqlite.wasm',
-  '/mc-wa-sqlite-async.wasm',
 ];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches
-      .open(STATIC_CACHE)
-      .then((cache) => cache.addAll(PRECACHE_URLS))
-      .then(() => self.skipWaiting())
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(PRECACHE_URLS))
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== STATIC_CACHE && key !== RUNTIME_CACHE)
-            .map((key) => caches.delete(key))
-        )
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== STATIC_CACHE && key !== RUNTIME_CACHE)
+          .map((key) => caches.delete(key))
       )
-      .then(() => self.clients.claim())
+    )
   );
 });
+
+function isCacheableResponse(response) {
+  return !!response && response.status === 200 && response.type === 'basic';
+}
 
 self.addEventListener('fetch', (event) => {
   const request = event.request;
@@ -60,8 +59,10 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone();
-          caches.open(RUNTIME_CACHE).then((cache) => cache.put('/', copy));
+          if (isCacheableResponse(response)) {
+            const copy = response.clone();
+            caches.open(RUNTIME_CACHE).then((cache) => cache.put('/', copy));
+          }
           return response;
         })
         .catch(() =>
@@ -75,7 +76,7 @@ self.addEventListener('fetch', (event) => {
     caches.match(request).then((cached) => {
       const networkFetch = fetch(request)
         .then((response) => {
-          if (response && response.status === 200 && response.type === 'basic') {
+          if (isCacheableResponse(response)) {
             const copy = response.clone();
             caches.open(RUNTIME_CACHE).then((cache) => cache.put(request, copy));
           }


### PR DESCRIPTION
Closes #113.

## Summary

Fixes the iPhone PWA crashing within ~30 seconds (both \"A problem repeatedly occurred\" and \"Safari can't open the page because the network connection was lost\"). Root cause turned out to be an iOS Safari incompatibility with PowerSync's default SQLite VFS.

## Root cause

PowerSync's `@powersync/web` defaults to `IDBBatchAtomicVFS`, which uses Asyncify over IndexedDB. On iOS Safari this deterministically overflows the call stack under sustained writes and causes the WebContent process to be terminated. PowerSync's own troubleshooting docs direct Safari users to `OPFSCoopSyncVFS` via `WASQLiteOpenFactory` (requires iOS 16.4+).

Earlier attempted fixes in this branch (SW v3 removing skipWaiting/clients.claim, web worker with explicit UMD URL, cacheSizeKb cap) addressed real issues but could not resolve the primary crash because none changed the VFS.

## Changes

- `db/openDatabase.web.ts` — switch to `WASQLiteOpenFactory` with `vfs: WASQLiteVFS.OPFSCoopSyncVFS`
- `lib/crashLog.ts` (new) — localStorage ring-buffer breadcrumbs + global `error` / `unhandledrejection` / `pageshow` / `visibilitychange` handlers; exposes `window._smcLog`, `window._smcLogClear`, `window._smcBuild`
- `app/_layout.tsx` — installs global crash handlers at module load
- `providers/DatabaseProvider.tsx` — breadcrumbs for init/connect/auth/errors; logs resolved VFS
- `providers/AuthProvider.tsx` — breadcrumbs on auth state changes
- `lib/registerServiceWorker.ts` — updated build marker, SW event breadcrumbs
- Earlier commits in this branch: SW v3 (no skipWaiting/clients.claim), PWA manifest `id: /`, explicit wa-sqlite worker UMD URL, `cacheSizeKb: 4 * 1024`

## Verified

- 58 Jest tests pass
- iOS Simulator (iPhone 17 Pro / iOS 26.2) against both localhost dev build and deployed production URL — login page idle 95+ seconds, OPFS storage files present, `db.init.done { vfs: 'OPFSCoopSyncVFS' }` confirmed in breadcrumbs
- Real iPhone 12 (iOS 26.2.1) in Safari — login, round creation, and scoring flow all stable; previously crashed within 30s

## Not verified

- PWA standalone (home-screen shortcut) mode — only Safari tab verified on the real device
- Extended sync scenarios (offline → online with queued writes)
- Behaviour on iOS < 16.4 (OPFSCoopSyncVFS requires it)

## Migration note

Existing iOS users have an IDB-backed SQLite DB from the previous VFS. After this ships, their device opens a new, empty OPFS-backed DB under the same filename and re-syncs from Supabase. The orphaned IDB file is harmless but can be cleared via Settings → Safari → Clear History and Website Data.

## Test plan

- [ ] Verify PWA on iPhone 12 after clearing site data — login, round creation, scoring stay stable through 2+ minutes
- [ ] Confirm `_smcLog()` in console returns breadcrumbs including `db.init.done { vfs: 'OPFSCoopSyncVFS' }`
- [ ] Confirm no regressions on desktop Safari / Chrome / Firefox

## Follow-ups (to be filed as separate issues)

- Duplicate `onAuthStateChange` listeners in `DatabaseProvider` + `AuthProvider`
- Missing `db.connected` guard on TOKEN_REFRESHED in `DatabaseProvider.tsx:33`
- 4 concurrent `db.watch()` subscriptions in `app/round/[id]/score.tsx`
- No error boundary around `db.connect`