### PR TITLE
chore: ignore local .smc-visual screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,10 @@ expo-env.d.ts
 ios/
 android/
 
-# AI workflow 
+# Local visual reference screenshots
+.smc-visual/
+
+# AI workflow
 .agents/
 .ai-policy/
 .claude/


### PR DESCRIPTION
Adds `.smc-visual/` to `.gitignore` so local visual-reference screenshots (captured during design-system work) are not accidentally committed.

Follow-up housekeeping from #117 / PR #123.