### PR TITLE
fix: wire PowerSync shared sync worker on web (#125)

### DIFF
--- a/__tests__/lib/powersync-connector.test.ts
+++ b/__tests__/lib/powersync-connector.test.ts
@@ -53,6 +53,41 @@ describe('SupabaseConnector', () => {
     });
   });
 
+  describe('reportError', () => {
+    it('notifies all registered listeners with an Error', () => {
+      const a = jest.fn();
+      const b = jest.fn();
+      connector.addErrorListener(a);
+      connector.addErrorListener(b);
+
+      const err = new Error('connect failed');
+      connector.reportError(err);
+
+      expect(a).toHaveBeenCalledWith(err);
+      expect(b).toHaveBeenCalledWith(err);
+    });
+
+    it('wraps non-Error values in an Error', () => {
+      const listener = jest.fn();
+      connector.addErrorListener(listener);
+
+      connector.reportError('boom');
+
+      expect(listener).toHaveBeenCalledWith(expect.any(Error));
+      expect(listener.mock.calls[0][0].message).toBe('boom');
+    });
+
+    it('does not notify a removed listener', () => {
+      const listener = jest.fn();
+      const remove = connector.addErrorListener(listener);
+      remove();
+
+      connector.reportError(new Error('x'));
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   describe('uploadData', () => {
     it('skips read-only tables (clubs, club_positions, club_stands)', async () => {
       const mockDb = {

--- a/db/openDatabase.web.ts
+++ b/db/openDatabase.web.ts
@@ -24,4 +24,13 @@ export const db = new PowerSyncDatabase({
   schema: AppSchema,
   database: openFactory,
   flags: { useWebWorker: true },
+  // The shared sync worker must be pointed at the copied UMD asset for the
+  // same reason as the DB worker above: PowerSync's default resolves the
+  // worker via `new URL(..., import.meta.url)` with `type: 'module'`, which
+  // Metro cannot bundle. Left unset, SharedWorker construction fails, the
+  // message port is undefined, and connect throws "Cannot read properties of
+  // undefined (reading 'addEventListener')" — stalling sync entirely.
+  sync: {
+    worker: '/@powersync/worker/SharedSyncImplementation.umd.js',
+  },
 });

--- a/lib/powersync-connector.ts
+++ b/lib/powersync-connector.ts
@@ -15,6 +15,18 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     return () => this.errorListeners.delete(listener);
   }
 
+  /**
+   * Surface an error to all registered listeners (e.g. the SyncProvider banner).
+   * Used for connect/sync failures that happen outside uploadData, so a failed
+   * sync is visible to the user instead of leaving a silently empty app.
+   */
+  public reportError(error: unknown) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    for (const listener of this.errorListeners) {
+      listener(err);
+    }
+  }
+
   async fetchCredentials(): Promise<PowerSyncCredentials | null> {
     // Use cached session to avoid deadlock when called from onAuthStateChange
     const session = this.currentSession;
@@ -73,9 +85,7 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
         // Rethrowing would block the entire CRUD queue forever.
         const err = error instanceof Error ? error : new Error(String(error));
         console.error(`Upload error (skipping): ${err.message}`);
-        for (const listener of this.errorListeners) {
-          listener(err);
-        }
+        this.reportError(err);
       }
     }
 

--- a/providers/DatabaseProvider.tsx
+++ b/providers/DatabaseProvider.tsx
@@ -39,6 +39,7 @@ export function DatabaseProvider({ children }: { children: ReactNode }) {
               .catch(err => {
                 breadcrumb('db.connect.error', { message: err instanceof Error ? err.message : String(err) });
                 console.error('[DB] Connect error:', err);
+                connector.reportError(err);
               });
           }
         }


### PR DESCRIPTION
Fixes #125.

## Problem
On web, a signed-in user saw none of their data — Home/History showed "No rounds yet" despite the account having rounds, scores, clubs and invites on the backend. PowerSync authenticated but never streamed data into the local SQLite. Crash breadcrumbs showed `Cannot read properties of undefined (reading 'addEventListener')` on connect.

## Root cause
On web, `enableMultiTabs` (default) selects `SharedWebStreamingSyncImplementation`, which needs a shared **sync** worker. `db/openDatabase.web.ts` already points the **DB** worker at a copied UMD asset to dodge Metro's `import.meta` limitation, but the sync worker was never configured. Left unset, PowerSync falls back to `new SharedWorker(new URL('…SharedSyncImplementation.worker.js', import.meta.url), { type: 'module' })` — which Metro cannot bundle. The SharedWorker construction fails, `messagePort` is undefined, and `Comlink.expose(clientProvider, messagePort)` calls `messagePort.addEventListener('message', …)` → the observed error. Sync stalls entirely (even global reference `clubs` were absent locally), leaving a silently empty app.

## Fix
- `db/openDatabase.web.ts`: set `sync.worker` to the copied UMD asset `/@powersync/worker/SharedSyncImplementation.umd.js` (already copied by the existing postinstall), mirroring the DB-worker treatment in the same file. The string-URL branch avoids `import.meta` and `type: 'module'`.
- `lib/powersync-connector.ts`: add a public `reportError`; reuse it in `uploadData`.
- `providers/DatabaseProvider.tsx`: route connect-time failures through `reportError` so a stalled sync surfaces the `SyncProvider` banner instead of a silent empty app (acceptance criterion #2).

## Verification
- End-to-end on the real backend (web, localhost): after sign-in, Home/History/round-summary populate. All 23 rounds present, 8 reference clubs present (the data absent during the stall), rounds with scores show "50 targets". Console shows `db.connect.done` with no connect error and no `addEventListener` exception, including after a cache-busting reload.
- `npm test`: 61/61 pass (+3 new `reportError` tests). `tsc --noEmit` clean.

## Scope / follow-ups
- **Native (acceptance criterion #3):** this failure is structurally web-only — native (`@powersync/react-native`) has no SharedWorker/Comlink/`import.meta` worker path. Confirmed by code; a positive native runtime check on a device remains a human task.
- The error-banner path is unit-tested and wired, but could not be observed end-to-end because the fix prevents the failure that would trigger it.
- Related #115 (duplicate auth listeners) and #116 (reconnect guard) touch the same connect path but are left out of scope.