### PR TITLE
chore: update vendored AI workflow 3.3.0 -> 3.5.2

### DIFF
--- a/.ai-policy/scripts/project-validation.sh
+++ b/.ai-policy/scripts/project-validation.sh
@@ -4,6 +4,8 @@
 # Validates only the policy layer itself: shell-script syntax plus enforcement tests
 # that match the agent entry points actually installed in this repo.
 # If ./scripts/repo-validation.sh exists and is executable, runs it afterwards for repo-specific checks.
+# If it is absent, warns loudly that only the policy layer ran so a "passed" result is
+# not mistaken for the host project's own tests/lint/type-checks having run.
 set -eu
 
 bash -n ./.ai-policy/scripts/*.sh ./.ai-policy/hooks/*.sh ./.githooks/*
@@ -29,5 +31,13 @@ for t in ./.ai-policy/scripts/test-*.sh; do
 done
 
 if [ -x ./scripts/repo-validation.sh ]; then
+  echo "Running repo-specific checks from ./scripts/repo-validation.sh ..."
   ./scripts/repo-validation.sh
+else
+  echo "WARNING: no ./scripts/repo-validation.sh found."
+  echo "         Validation ran ONLY this workflow's policy-layer self-checks."
+  echo "         Your project's own tests, linters, and type checks were NOT run,"
+  echo "         so a \"passed\" result here does not mean your code is validated."
+  echo "         Wire your checks in by creating an executable ./scripts/repo-validation.sh"
+  echo "         (see README 'Post-install setup')."
 fi

--- a/.claude/skills/aiw-issue-creation/SKILL.md
+++ b/.claude/skills/aiw-issue-creation/SKILL.md
@@ -19,18 +19,18 @@ Read this file when creating a follow-up or spin-off GitHub issue.
 - State why the change is needed and what triggered the discovery.
 - State acceptance criteria if they are clear.
 
-## Referencing Code
+## What the Issue May Contain
 
-- Point to the relevant files, directories, or entry points when they help the reader find where the work starts.
-- Frame references as starting points for orientation, not as boundaries or a prescribed solution.
-- Prefer stable references (files, directories, modules) over volatile ones.
+- Reference relevant files by path to locate the concern, so the implementing agent can open current truth in the codebase. Point at the file; never restate, paste, or paraphrase its contents.
+- Optionally, a short list of workflow skills that may help whoever implements it. Frame this as a hint to orient the implementing agent, not a mandate or a prescribed solution.
 
 ## What the Issue Must Not Contain
 
+- Do not restate, paste, or paraphrase the contents of any file. A path that locates the concern is allowed (see above); reproducing what the file says is not.
+- Do not include code snippets or implementation approaches.
+- Do not reference specific functions, variables, or line numbers.
 - Do not prescribe how the implementing agent should solve the problem.
-- Do not include code snippets or a step-by-step implementation plan.
-- Do not pin to specific line numbers, function names, or variable names, which drift as the code changes.
-  (Why: prescribing the solution or pinning to volatile code locations biases the implementing agent toward an approach that may not match the codebase when the issue is picked up; file- and directory-level references orient the reader without prescribing.)
+  (Why: A bare path only locates the concern, but restated file contents, an implementation approach, or a function/line reference peg the issue to the current codebase state and bias the implementing agent toward an approach that may not match the codebase when the issue is picked up.)
 
 ## Keeping Issues Concise
 

--- a/ai-workflow.md
+++ b/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI Workflow
 
-Version: 3.3.0
+Version: 3.5.2
 
 This file defines the rules and processes for AI-assisted coding on this project.
 It is written for the AI coding agent.
@@ -71,6 +71,10 @@ Do not do any of the following under any circumstances:
 - NEVER claim the issue is nearly complete while the root cause is still unknown.
 - NEVER hardcode sensitive values.
 - NEVER bypass deterministic policy checks or treat them as optional.
+
+## Asking for Guidance
+
+When asking the human a question or requesting guidance on a decision, present it as: a short paragraph framing the situation, a list of options each with an explanation, a clear recommendation, then the rationale for that recommendation.
 
 ## Reactive Rules
 


### PR DESCRIPTION
Updates the installed AI coding workflow (`philippe-ths/ai-coding-workflow`) from 3.3.0 to 3.5.2 for the Claude install, via the supported updater.

## Changes
- **ai-workflow.md** — version bump + new *Asking for Guidance* section (3.5.0).
- **aiw-issue-creation** — issues may reference file paths but not paste/paraphrase file contents (3.4.0).
- **project-validation.sh** — warns loudly when no `scripts/repo-validation.sh` is wired, so a policy-layer-only pass is not mistaken for the app's tests running (3.4.1).

## Deliberately not adopted
The 3.5.2 `pre-push` hook re-adds a changelog-discipline check that blocks pushing any `ai-workflow.md` version bump without a matching `CHANGELOG.md` entry. This repo only vendors the workflow and keeps no such changelog, so `pre-push` is left at its prior (committed) state. Note: this will be re-applied by the updater on the next upgrade unless fixed upstream.

## Notes
- `.gitignore` left untouched; the committed-vs-vendored reconciliation is tracked separately in #119.
- The new `test-project-validation.sh` and other files under `.ai-policy/`/`.claude/` are gitignored in this repo, so they are not part of this diff.
- Policy-layer validation passes (22/22).

Closes #127